### PR TITLE
Add promotion management workflow with booking discounts

### DIFF
--- a/Admin/assets/js/promotion-form.js
+++ b/Admin/assets/js/promotion-form.js
@@ -91,80 +91,142 @@
     }
   }
 
-  function createOptionRow(option, enabled = true) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'promotion-option-row border rounded p-3 mb-2';
-    wrapper.dataset.optionId = option.option_id;
-    wrapper.dataset.price = option.price ?? 0;
-    wrapper.dataset.discount = option.discount_amount ?? 0;
-    wrapper.dataset.final = option.final_price ?? option.price ?? 0;
+function createOptionRow(option, enabled = true) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'promotion-option-row';
+  wrapper.dataset.optionId = option.option_id;
+  wrapper.dataset.price = option.price ?? 0;
+  wrapper.dataset.discount = option.discount_amount ?? 0;
+  wrapper.dataset.final = option.final_price ?? option.price ?? 0;
 
-    const isInitiallyEnabled = Boolean(enabled && (option.included !== false));
-    const percentValue = clampPercent(option.discount_percent ?? 0);
+  const isInitiallyEnabled = Boolean(enabled && (option.included !== false));
+  const percentValue = clampPercent(option.discount_percent ?? 0);
 
-    wrapper.innerHTML = `
-      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-        <div class="form-check form-switch">
-          <input class="form-check-input promotion-option-toggle" type="checkbox" ${isInitiallyEnabled ? 'checked' : ''}>
-          <label class="form-check-label">
-            ระยะเวลา ${option.duration ?? '-'} นาที - ราคา ${formatCurrency(option.price)}
-          </label>
-        </div>
-        <div class="d-flex align-items-center gap-2 promotion-option-details ${isInitiallyEnabled ? '' : 'text-muted'}">
-          <div class="input-group input-group-sm">
-            <input type="number" min="0" max="100" step="0.01" class="form-control promotion-option-percent" value="${percentValue}" ${isInitiallyEnabled ? '' : 'disabled'}>
-            <span class="input-group-text">%</span>
-          </div>
-          <div class="text-nowrap">
-            ส่วนลด <span data-discount-amount>${formatCurrency(option.discount_amount ?? 0)}</span>
-          </div>
-          <div class="text-nowrap">
-            ราคาสุทธิ <span data-final-price>${formatCurrency(option.final_price ?? option.price)}</span>
-          </div>
-        </div>
+  // 1 แถว = 5 คอลัมน์ (ระยะเวลา, ราคาเดิม, % ส่วนลด, ราคาสุทธิ, เปิดใช้งาน)
+  // ใช้ inline style ทั้งหมด เพื่อตัดเส้นน้ำเงินตอน focus + ทำให้ดูเป็นตาราง
+ wrapper.innerHTML = `
+  <div style="display:grid;grid-template-columns:1.2fr .8fr .9fr .9fr .7fr;
+              gap:12px;align-items:center;
+              padding:10px 12px;border-top:1px solid #eee;">
+    <div style="min-width:0;">
+      <div style="font-weight:600;color:#2b2b2b;">
+        ${option.duration ?? '-'} นาที
       </div>
-    `;
+    </div>
 
-    const percentInput = wrapper.querySelector('.promotion-option-percent');
-    const toggle = wrapper.querySelector('.promotion-option-toggle');
-    percentInput.addEventListener('input', handlePercentInput);
-    toggle.addEventListener('change', handleToggleChange);
-    if (isInitiallyEnabled) {
-      recalcOptionRow(wrapper);
-    }
-    return wrapper;
+    <div style="text-align:center;white-space:nowrap;">
+      ${formatCurrency(option.price)}
+    </div>
+
+    <div style="text-align:center;">
+      <div style="display:inline-flex;align-items:center;gap:6px;">
+        <input type="number" min="0" max="100" step="0.01"
+               class="promotion-option-percent"
+               value="${percentValue}" ${isInitiallyEnabled ? '' : 'disabled'}
+               style="width:90px;text-align:center;padding:6px 8px;
+                      border:1px solid #ccc;border-radius:8px;
+                      outline:none;box-shadow:none;
+                      ${isInitiallyEnabled ? '' : 'background:#f2f2f2;color:#9a9a9a;'}">
+        <span style="color:#333;">%</span>
+      </div>
+    </div>
+
+    <div style="text-align:center;white-space:nowrap;">
+      <span data-final-price>
+        ${formatCurrency(option.final_price ?? option.price)}
+      </span>
+      <div style="font-size:12px;color:#7a7a7a;">
+        ส่วนลด <span data-discount-amount>
+          ${formatCurrency(option.discount_amount ?? 0)}
+        </span>
+      </div>
+    </div>
+
+    <!-- ช่องสวิตช์ เปิด/ปิด -->
+    <div style="text-align:center;display:flex;justify-content:center;align-items:center;">
+      <div class="form-check form-switch mb-0">
+        <input class="form-check-input promotion-option-toggle shadow-none"
+               type="checkbox"
+               role="switch"
+               ${isInitiallyEnabled ? 'checked' : ''}
+               style="width:3rem;height:1.5rem;cursor:pointer;">
+      </div>
+    </div>
+  </div>
+`;
+
+// ทำปุ่มสวิตช์มีปุ่มกลมเลื่อน
+const toggle = wrapper.querySelector('.promotion-option-toggle');
+
+// events
+const percentInput = wrapper.querySelector('.promotion-option-percent');
+percentInput.addEventListener('input', handlePercentInput);
+
+toggle.addEventListener('change', (e) => {
+  const on = e.target.checked;
+
+  // ✅ ปิด/เปิดการกรอกเปอร์เซ็นต์เมื่อสวิตช์เปลี่ยน
+  percentInput.disabled = !on;
+
+  // ถ้าปิดให้รีเซ็ตส่วนลดเป็น 0 และคำนวณราคาใหม่
+  if (!on) {
+    percentInput.value = 0;
+    recalcOptionRow(wrapper);
+  } else {
+    recalcOptionRow(wrapper);
   }
 
-  function createServiceCard(service) {
-    const card = document.createElement('div');
-    card.className = 'col-12 mb-3';
-    card.dataset.serviceId = service.service_id;
-    const header = document.createElement('div');
-    header.className = 'card border border-primary';
-    header.innerHTML = `
-      <div class="card-header d-flex justify-content-between align-items-center">
-        <h5 class="mb-0">${service.service_name}</h5>
-        <button type="button" class="btn btn-sm btn-outline-danger" data-remove-service>&times;</button>
+  handleToggleChange(e);
+});
+
+  if (isInitiallyEnabled) recalcOptionRow(wrapper);
+  return wrapper;
+}
+
+
+function createServiceCard(service) {
+  const card = document.createElement('div');
+  card.className = 'col-12 mb-3';
+  card.dataset.serviceId = service.service_id;
+
+  const header = document.createElement('div');
+  header.className = 'card';
+  header.innerHTML = `
+    <div class="card-header d-flex justify-content-between align-items-center" style="background:#f8f9fa;border:1px solid #e0e0e0;border-top-left-radius:8px;border-top-right-radius:8px;">
+      <h5 class="mb-0" style="font-size:16px;">${service.service_name}</h5>
+      <button type="button" class="btn btn-sm btn-outline-danger" data-remove-service>&times;</button>
+    </div>
+    <div class="card-body p-0" style="border:1px solid #e0e0e0;border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;overflow:hidden;">
+      <!-- หัวตาราง -->
+      <div style="display:grid;grid-template-columns:1.2fr .8fr .9fr .9fr .7fr;gap:12px;align-items:center;
+                  padding:10px 12px;background:#f8f9fa;font-weight:600;">
+        <div>ระยะเวลา</div>
+        <div style="text-align:center;">ราคาเดิม</div>
+        <div style="text-align:center;">ส่วนลด (%)</div>
+        <div style="text-align:center;">ราคาสุทธิ</div>
+        <div style="text-align:center;">เปิดใช้งาน</div>
       </div>
-      <div class="card-body" data-option-container></div>
-    `;
-    card.appendChild(header);
+      <div data-option-container></div>
+    </div>
+  `;
+  card.appendChild(header);
 
-    const optionContainer = header.querySelector('[data-option-container]');
-    (service.options || []).forEach(option => {
-      const isIncluded = option.included !== false;
-      const row = createOptionRow(option, isIncluded);
-      optionContainer.appendChild(row);
-    });
+  const optionContainer = header.querySelector('[data-option-container]');
+  (service.options || []).forEach(option => {
+    const isIncluded = option.included !== false;
+    const row = createOptionRow(option, isIncluded);
+    optionContainer.appendChild(row);
+  });
 
-    header.querySelector('[data-remove-service]').addEventListener('click', () => {
-      selectedServiceIds.delete(service.service_id);
-      card.remove();
-      updateEmptyState();
-    });
+  header.querySelector('[data-remove-service]').addEventListener('click', () => {
+    selectedServiceIds.delete(service.service_id);
+    card.remove();
+    updateEmptyState();
+  });
 
-    return card;
-  }
+  return card;
+}
+
 
   function renderService(service) {
     if (selectedServiceIds.has(service.service_id)) {

--- a/Admin/assets/js/promotion-form.js
+++ b/Admin/assets/js/promotion-form.js
@@ -1,0 +1,362 @@
+(function () {
+  const form = document.querySelector('[data-promotion-form]');
+  if (!form) {
+    return;
+  }
+
+  const config = window.promotionFormConfig || {};
+  const startInput = form.querySelector('input[name="pm_start_date"]');
+  const endInput = form.querySelector('input[name="pm_end_date"]');
+  const selectedContainer = form.querySelector('[data-selected-services]');
+  const addServiceBtn = form.querySelector('[data-add-service]');
+  const emptyState = form.querySelector('[data-empty-state]');
+  const payloadInput = form.querySelector('[data-payload]');
+
+  const modalEl = document.getElementById('serviceSelectModal');
+  const modal = modalEl ? new bootstrap.Modal(modalEl) : null;
+  const modalWarning = modalEl ? modalEl.querySelector('[data-modal-warning]') : null;
+  const serviceList = modalEl ? modalEl.querySelector('[data-service-checkboxes]') : null;
+  const selectAllCheckbox = modalEl ? modalEl.querySelector('[data-select-all]') : null;
+  const noServiceInfo = modalEl ? modalEl.querySelector('[data-no-service]') : null;
+  const confirmServicesBtn = modalEl ? modalEl.querySelector('[data-confirm-services]') : null;
+
+  const selectedServiceIds = new Set();
+
+  function updateEmptyState() {
+    if (!emptyState) return;
+    if (selectedServiceIds.size === 0) {
+      emptyState.classList.remove('d-none');
+    } else {
+      emptyState.classList.add('d-none');
+    }
+  }
+
+  function clampPercent(value) {
+    let v = parseFloat(value);
+    if (isNaN(v) || v < 0) v = 0;
+    if (v > 100) v = 100;
+    return v;
+  }
+
+  function formatCurrency(value) {
+    return '฿' + Number(value || 0).toFixed(2);
+  }
+
+  function recalcOptionRow(row) {
+    const price = parseFloat(row.dataset.price || '0');
+    const percentInput = row.querySelector('.promotion-option-percent');
+    const percent = clampPercent(percentInput.value);
+    percentInput.value = percent;
+    const discountAmount = price * percent / 100;
+    const finalPrice = price - discountAmount;
+
+    row.dataset.discount = discountAmount.toFixed(2);
+    row.dataset.final = finalPrice.toFixed(2);
+
+    const discountLabel = row.querySelector('[data-discount-amount]');
+    const finalLabel = row.querySelector('[data-final-price]');
+    if (discountLabel) {
+      discountLabel.textContent = formatCurrency(discountAmount);
+    }
+    if (finalLabel) {
+      finalLabel.textContent = formatCurrency(finalPrice);
+    }
+  }
+
+  function handlePercentInput(event) {
+    recalcOptionRow(event.target.closest('.promotion-option-row'));
+  }
+
+  function handleToggleChange(event) {
+    const row = event.target.closest('.promotion-option-row');
+    const percentInput = row.querySelector('.promotion-option-percent');
+    const details = row.querySelector('.promotion-option-details');
+    if (event.target.checked) {
+      percentInput.removeAttribute('disabled');
+      if (details) details.classList.remove('text-muted');
+      recalcOptionRow(row);
+    } else {
+      percentInput.setAttribute('disabled', 'disabled');
+      if (details) details.classList.add('text-muted');
+      row.dataset.discount = '0.00';
+      row.dataset.final = row.dataset.price;
+      const discountLabel = row.querySelector('[data-discount-amount]');
+      const finalLabel = row.querySelector('[data-final-price]');
+      if (discountLabel) {
+        discountLabel.textContent = formatCurrency(0);
+      }
+      if (finalLabel) {
+        finalLabel.textContent = formatCurrency(row.dataset.price);
+      }
+    }
+  }
+
+  function createOptionRow(option, enabled = true) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'promotion-option-row border rounded p-3 mb-2';
+    wrapper.dataset.optionId = option.option_id;
+    wrapper.dataset.price = option.price ?? 0;
+    wrapper.dataset.discount = option.discount_amount ?? 0;
+    wrapper.dataset.final = option.final_price ?? option.price ?? 0;
+
+    const isInitiallyEnabled = Boolean(enabled && (option.included !== false));
+    const percentValue = clampPercent(option.discount_percent ?? 0);
+
+    wrapper.innerHTML = `
+      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div class="form-check form-switch">
+          <input class="form-check-input promotion-option-toggle" type="checkbox" ${isInitiallyEnabled ? 'checked' : ''}>
+          <label class="form-check-label">
+            ระยะเวลา ${option.duration ?? '-'} นาที - ราคา ${formatCurrency(option.price)}
+          </label>
+        </div>
+        <div class="d-flex align-items-center gap-2 promotion-option-details ${isInitiallyEnabled ? '' : 'text-muted'}">
+          <div class="input-group input-group-sm">
+            <input type="number" min="0" max="100" step="0.01" class="form-control promotion-option-percent" value="${percentValue}" ${isInitiallyEnabled ? '' : 'disabled'}>
+            <span class="input-group-text">%</span>
+          </div>
+          <div class="text-nowrap">
+            ส่วนลด <span data-discount-amount>${formatCurrency(option.discount_amount ?? 0)}</span>
+          </div>
+          <div class="text-nowrap">
+            ราคาสุทธิ <span data-final-price>${formatCurrency(option.final_price ?? option.price)}</span>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const percentInput = wrapper.querySelector('.promotion-option-percent');
+    const toggle = wrapper.querySelector('.promotion-option-toggle');
+    percentInput.addEventListener('input', handlePercentInput);
+    toggle.addEventListener('change', handleToggleChange);
+    if (isInitiallyEnabled) {
+      recalcOptionRow(wrapper);
+    }
+    return wrapper;
+  }
+
+  function createServiceCard(service) {
+    const card = document.createElement('div');
+    card.className = 'col-lg-6';
+    card.dataset.serviceId = service.service_id;
+    const header = document.createElement('div');
+    header.className = 'card border border-primary h-100';
+    header.innerHTML = `
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">${service.service_name}</h5>
+        <button type="button" class="btn btn-sm btn-outline-danger" data-remove-service>&times;</button>
+      </div>
+      <div class="card-body" data-option-container></div>
+    `;
+    card.appendChild(header);
+
+    const optionContainer = header.querySelector('[data-option-container]');
+    (service.options || []).forEach(option => {
+      const isIncluded = option.included !== false;
+      const row = createOptionRow(option, isIncluded);
+      optionContainer.appendChild(row);
+    });
+
+    header.querySelector('[data-remove-service]').addEventListener('click', () => {
+      selectedServiceIds.delete(service.service_id);
+      card.remove();
+      updateEmptyState();
+    });
+
+    return card;
+  }
+
+  function renderService(service) {
+    if (selectedServiceIds.has(service.service_id)) {
+      return;
+    }
+    selectedServiceIds.add(service.service_id);
+    const card = createServiceCard(service);
+    selectedContainer.appendChild(card);
+    updateEmptyState();
+  }
+
+  function fetchServiceOptions(serviceId) {
+    const url = `${config.optionsUrl}?service_id=${encodeURIComponent(serviceId)}`;
+    return fetch(url)
+      .then(res => res.json())
+      .then(options => Array.isArray(options) ? options : [])
+      .catch(() => []);
+  }
+
+  function fetchAvailableServices() {
+    if (!serviceList) return Promise.resolve([]);
+    const start = startInput ? startInput.value : '';
+    const end = endInput ? endInput.value : '';
+
+    if (!start || !end) {
+      if (modalWarning) modalWarning.classList.remove('d-none');
+      return Promise.resolve([]);
+    }
+    if (modalWarning) modalWarning.classList.add('d-none');
+
+    const params = new URLSearchParams({ start, end });
+    if (config.promotionId) {
+      params.append('promotion_id', config.promotionId);
+    }
+
+    return fetch(`${config.availableServiceUrl}?${params.toString()}`)
+      .then(res => res.json())
+      .then(data => Array.isArray(data) ? data : [])
+      .catch(() => []);
+  }
+
+  function openServiceModal() {
+    if (!modal) return;
+    fetchAvailableServices().then(services => {
+      serviceList.innerHTML = '';
+      if (selectAllCheckbox) {
+        selectAllCheckbox.checked = false;
+      }
+      if (!services.length) {
+        if (noServiceInfo) noServiceInfo.classList.remove('d-none');
+      } else {
+        if (noServiceInfo) noServiceInfo.classList.add('d-none');
+        services.forEach(service => {
+          const item = document.createElement('label');
+          item.className = 'list-group-item list-group-item-action';
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.className = 'form-check-input me-2';
+          checkbox.value = service.service_id;
+          checkbox.dataset.name = service.service_name;
+          if (selectedServiceIds.has(service.service_id)) {
+            checkbox.disabled = true;
+          }
+          item.appendChild(checkbox);
+          item.append(` ${service.service_name}`);
+          serviceList.appendChild(item);
+        });
+      }
+      modal.show();
+    });
+  }
+
+  function handleSelectAll() {
+    if (!serviceList) return;
+    const checkboxes = serviceList.querySelectorAll('input[type="checkbox"]:not(:disabled)');
+    checkboxes.forEach(cb => {
+      cb.checked = selectAllCheckbox.checked;
+    });
+  }
+
+  function handleConfirmServices() {
+    if (!serviceList) return;
+    const checkboxes = serviceList.querySelectorAll('input[type="checkbox"]:checked');
+    const selections = Array.from(checkboxes).map(cb => ({
+      service_id: parseInt(cb.value, 10),
+      service_name: cb.dataset.name || ''
+    })).filter(service => service.service_id && !selectedServiceIds.has(service.service_id));
+
+    if (!selections.length) {
+      if (modal) modal.hide();
+      return;
+    }
+
+    const promises = selections.map(service => {
+      return fetchServiceOptions(service.service_id).then(options => {
+        service.options = options.map(opt => ({
+          option_id: opt.option_id,
+          duration: opt.duration,
+          price: parseFloat(opt.price || 0),
+          discount_percent: 0,
+          discount_amount: 0,
+          final_price: parseFloat(opt.price || 0),
+          included: true
+        }));
+        return service;
+      });
+    });
+
+    Promise.all(promises).then(list => {
+      list.forEach(renderService);
+      if (modal) modal.hide();
+    });
+  }
+
+  function collectPayload() {
+    const payload = [];
+    const cards = selectedContainer.querySelectorAll('[data-service-id]');
+    cards.forEach(card => {
+      const serviceId = parseInt(card.dataset.serviceId, 10);
+      if (!serviceId) return;
+      const options = [];
+      card.querySelectorAll('.promotion-option-row').forEach(row => {
+        const toggle = row.querySelector('.promotion-option-toggle');
+        if (!toggle || !toggle.checked) {
+          return;
+        }
+        const optionId = parseInt(row.dataset.optionId, 10);
+        if (!optionId) return;
+        const percentInput = row.querySelector('.promotion-option-percent');
+        const percent = clampPercent(percentInput.value);
+        options.push({
+          option_id: optionId,
+          discount_percent: percent
+        });
+      });
+      if (options.length > 0) {
+        payload.push({ service_id: serviceId, options });
+      }
+    });
+    return payload;
+  }
+
+  function validateDates() {
+    if (!startInput || !endInput) return true;
+    if (!startInput.value || !endInput.value) return false;
+    const start = new Date(startInput.value);
+    const end = new Date(endInput.value);
+    return !isNaN(start.getTime()) && !isNaN(end.getTime()) && end > start;
+  }
+
+  form.addEventListener('submit', function (event) {
+    if (!validateDates()) {
+      event.preventDefault();
+      alert('กรุณาระบุวันและเวลาที่ถูกต้อง');
+      return;
+    }
+
+    const payload = collectPayload();
+    if (!payload.length) {
+      event.preventDefault();
+      alert('กรุณาเลือกบริการและ option ที่ต้องการจัดโปรโมชั่น');
+      return;
+    }
+
+    payloadInput.value = JSON.stringify(payload);
+  });
+
+  if (addServiceBtn) {
+    addServiceBtn.addEventListener('click', openServiceModal);
+  }
+  if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener('change', handleSelectAll);
+  }
+  if (confirmServicesBtn) {
+    confirmServicesBtn.addEventListener('click', handleConfirmServices);
+  }
+
+  // Initialize with existing services if provided
+  if (Array.isArray(config.initialServices)) {
+    config.initialServices.forEach(service => {
+      service.options = (service.options || []).map(opt => ({
+        option_id: opt.option_id,
+        duration: opt.duration,
+        price: parseFloat(opt.price ?? 0),
+        discount_percent: opt.discount_percent ?? 0,
+        discount_amount: parseFloat(opt.discount_amount ?? 0),
+        final_price: parseFloat(opt.final_price ?? opt.price ?? 0),
+        included: opt.included !== false
+      }));
+      renderService(service);
+    });
+  }
+
+  updateEmptyState();
+})();

--- a/Admin/assets/js/promotion-form.js
+++ b/Admin/assets/js/promotion-form.js
@@ -137,10 +137,10 @@
 
   function createServiceCard(service) {
     const card = document.createElement('div');
-    card.className = 'col-lg-6';
+    card.className = 'col-12 mb-3';
     card.dataset.serviceId = service.service_id;
     const header = document.createElement('div');
-    header.className = 'card border border-primary h-100';
+    header.className = 'card border border-primary';
     header.innerHTML = `
       <div class="card-header d-flex justify-content-between align-items-center">
         <h5 class="mb-0">${service.service_name}</h5>

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -345,6 +345,16 @@
       calculatePrices();
     }
 
+    // ---------- Helpers for promotion timing ----------
+    function getCurrentBookingMoment(){
+      const now = new Date();
+      const pad = (value) => value.toString().padStart(2, '0');
+      return {
+        date: `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`,
+        time: `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
+      };
+    }
+
     // ---------- Price summary ----------
     async function calculatePrices(){
       const priceTable = document.getElementById('priceTable');
@@ -364,15 +374,14 @@
       });
 
       let discountMap = {};
-      const bookingDate = document.getElementById('bookingDate').value;
-      const startTime = document.getElementById('startTime').value;
+      const { date: bookingDate, time: bookingTime } = getCurrentBookingMoment();
 
-      if (optionIds.length && bookingDate){
+      if (optionIds.length){
         try {
           const response = await fetch('get_applicable_promotions.php', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ option_ids: optionIds, date: bookingDate, time: startTime })
+            body: JSON.stringify({ option_ids: optionIds, date: bookingDate, time: bookingTime })
           });
           if (response.ok){
             const data = await response.json();

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -135,6 +135,10 @@
                       <th id="totalPrice">€0.00</th>
                     </tr>
                     <tr>
+                      <th colspan="2">Discount</th>
+                      <th id="discountAmount">-€0.00</th>
+                    </tr>
+                    <tr>
                       <th colspan="2">Final Price</th>
                       <th id="finalPrice">€0.00</th>
                     </tr>
@@ -201,7 +205,10 @@
     flatpickr("#bookingDate", {
       dateFormat: "Y-m-d",
       minDate: "today",
-      onChange: function(selectedDates, dateStr){ loadAvailableTimes(dateStr); }
+      onChange: function(selectedDates, dateStr){
+        loadAvailableTimes(dateStr);
+        calculatePrices();
+      }
     });
 
     // ---------- Helpers ----------
@@ -334,13 +341,49 @@
           })
           .catch(() => {});
       }
+
+      calculatePrices();
     }
 
     // ---------- Price summary ----------
-    function calculatePrices(){
+    async function calculatePrices(){
       const priceTable = document.getElementById('priceTable');
       priceTable.innerHTML = '';
       let totalPrice = 0;
+      let totalDiscount = 0;
+      let optionIds = [];
+
+      const rows = document.querySelectorAll('.service-row');
+
+      rows.forEach(row => {
+        const oSel = row.querySelector('.option-select');
+        const optionId = parseInt(oSel?.value || '0', 10);
+        if (optionId > 0) {
+          optionIds.push(optionId);
+        }
+      });
+
+      let discountMap = {};
+      const bookingDate = document.getElementById('bookingDate').value;
+      const startTime = document.getElementById('startTime').value;
+
+      if (optionIds.length && bookingDate){
+        try {
+          const response = await fetch('get_applicable_promotions.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ option_ids: optionIds, date: bookingDate, time: startTime })
+          });
+          if (response.ok){
+            const data = await response.json();
+            if (data && typeof data === 'object'){
+              discountMap = data.option_discounts || {};
+            }
+          }
+        } catch (err) {
+          console.warn('Failed to fetch promotions', err);
+        }
+      }
 
       document.querySelectorAll('.service-row').forEach(row => {
         const sSel = row.querySelector('.service-select');
@@ -349,21 +392,34 @@
         const serviceName = sSel?.options[sSel.selectedIndex]?.text || '';
         const optionText  = oSel?.options[oSel.selectedIndex]?.text || '';
         const price = parseFloat(oSel?.options[oSel.selectedIndex]?.dataset.price || 0);
+        const optionId = parseInt(oSel?.value || '0', 10);
 
         if (serviceName && optionText && !isNaN(price) && price > 0){
+          const discountInfo = discountMap[optionId] || null;
+          const discountAmount = discountInfo ? parseFloat(discountInfo.discount_amount || 0) : 0;
+          const finalPrice = discountInfo ? parseFloat(discountInfo.final_price || (price - discountAmount)) : price;
+
           totalPrice += price;
+          totalDiscount += discountAmount;
+
+          let priceCell = `€${price.toFixed(2)}`;
+          if (discountAmount > 0){
+            priceCell = `€${finalPrice.toFixed(2)}<div class="text-muted small">ลด -€${discountAmount.toFixed(2)} จาก €${price.toFixed(2)}</div>`;
+          }
+
           priceTable.insertAdjacentHTML('beforeend', `
             <tr>
               <td>${serviceName}</td>
               <td>${optionText}</td>
-              <td>€${price.toFixed(2)}</td>
+              <td>${priceCell}</td>
             </tr>
           `);
         }
       });
 
       document.getElementById('totalPrice').textContent = `€${totalPrice.toFixed(2)}`;
-      document.getElementById('finalPrice').textContent = `€${totalPrice.toFixed(2)}`; // ยังไม่มีส่วนลด → final = total
+      document.getElementById('discountAmount').textContent = `-€${totalDiscount.toFixed(2)}`;
+      document.getElementById('finalPrice').textContent = `€${(totalPrice - totalDiscount).toFixed(2)}`;
     }
   </script>
 </main>

--- a/Admin/booking_detail.php
+++ b/Admin/booking_detail.php
@@ -55,7 +55,8 @@ if (!$booking) { echo "ไม่พบข้อมูลการจองนี
 
 /* ดึงรายการบริการที่จอง */
 $service_sql = "
-  SELECT sv.service_name, so.duration, so.price
+  SELECT sv.service_name, so.duration, so.price,
+         bs.price_booking, bs.discount_booking, bs.net_price
   FROM booking_seviceop bs
   JOIN service_option so ON bs.option_id = so.option_id
   JOIN service sv       ON so.service_id = sv.service_id
@@ -68,10 +69,14 @@ $service_result = $stmt2->get_result();
 $services = [];
 $totalMinutes = 0;
 $totalPrice   = 0.0;
+$totalDiscount = 0.0;
+$totalNet     = 0.0;
 while ($row = $service_result->fetch_assoc()) {
   $services[] = $row;
   $totalMinutes += (int)$row['duration'];
-  $totalPrice   += (float)$row['price'];
+  $totalPrice   += (float)($row['price_booking'] ?? $row['price']);
+  $totalDiscount += (float)($row['discount_booking'] ?? 0);
+  $totalNet     += (float)($row['net_price'] ?? ($row['price_booking'] ?? $row['price']));
 }
 $stmt2->close();
 
@@ -170,6 +175,8 @@ if ($status === 'pending') {
           <th>Service</th>
           <th class="text-center" style="width:120px;">Minutes</th>
           <th class="text-end" style="width:140px;">Price (฿)</th>
+          <th class="text-end" style="width:140px;">Discount (฿)</th>
+          <th class="text-end" style="width:140px;">Net (฿)</th>
         </tr>
       </thead>
       <tbody>
@@ -177,7 +184,9 @@ if ($status === 'pending') {
           <tr>
             <td><?= htmlspecialchars($srv['service_name']) ?></td>
             <td class="text-center"><?= (int)$srv['duration'] ?></td>
-            <td class="text-end"><?= number_format((float)$srv['price'], 2) ?></td>
+            <td class="text-end"><?= number_format((float)($srv['price_booking'] ?? $srv['price']), 2) ?></td>
+            <td class="text-end"><?= number_format((float)($srv['discount_booking'] ?? 0), 2) ?></td>
+            <td class="text-end"><?= number_format((float)($srv['net_price'] ?? ($srv['price_booking'] ?? $srv['price'])), 2) ?></td>
           </tr>
         <?php endforeach; ?>
       </tbody>
@@ -186,6 +195,8 @@ if ($status === 'pending') {
           <td class="text-end">Total</td>
           <td class="text-center"><?= (int)$totalMinutes ?></td>
           <td class="text-end">฿<?= number_format($totalPrice, 2) ?></td>
+          <td class="text-end">฿<?= number_format($totalDiscount, 2) ?></td>
+          <td class="text-end">฿<?= number_format($totalNet, 2) ?></td>
         </tr>
       </tfoot>
     </table>
@@ -198,11 +209,11 @@ if ($status === 'pending') {
       <table class="table table-bordered summary-table mb-4">
         <tr>
           <th>Total Discount</th>
-          <td><?= htmlspecialchars((string)$booking['total_discount']) !== '' ? htmlspecialchars($booking['total_discount']) : '—' ?></td>
+          <td>฿<?= number_format((float)($booking['total_discount'] ?? $totalDiscount), 2) ?></td>
         </tr>
         <tr>
           <th>Discount Detail</th>
-          <td><?= htmlspecialchars($booking['discount_detail'] ?: '—') ?></td>
+          <td><?= $booking['discount_detail'] ? nl2br(htmlspecialchars($booking['discount_detail'])) : '—' ?></td>
         </tr>
         <tr>
           <th>Final Price (€)</th>

--- a/Admin/check_promotion.php
+++ b/Admin/check_promotion.php
@@ -1,3 +1,35 @@
 <?php
-header('Content-Type: application/json');
-echo json_encode(false);
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$date = $_GET['date'] ?? '';
+$time = $_GET['time'] ?? '';
+$optionIds = [];
+if (!empty($_GET['option_ids'])) {
+    $ids = explode(',', $_GET['option_ids']);
+    foreach ($ids as $id) {
+        $optionIds[] = (int) $id;
+    }
+}
+
+if (empty($optionIds) || empty($date)) {
+    echo json_encode(['success' => true, 'option_discounts' => [], 'total_discount' => 0.0]);
+    exit;
+}
+
+$target = combineDateAndTime($date, $time);
+if (!$target) {
+    echo json_encode(['success' => true, 'option_discounts' => [], 'total_discount' => 0.0]);
+    exit;
+}
+
+ensurePromotionSupport($conn);
+$result = getApplicableOptionDiscounts($conn, $optionIds, $target);
+
+echo json_encode([
+    'success' => true,
+    'option_discounts' => $result['by_option'],
+    'total_discount' => $result['total_discount'],
+]);

--- a/Admin/form_promotion.php
+++ b/Admin/form_promotion.php
@@ -1,28 +1,22 @@
 <?php
-require_once("connect_db.php");
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
-// Fetch all services
-$services = [];
-$sql = "SELECT * FROM service";
-$result = mysqli_query($conn, $sql);
-while ($row = mysqli_fetch_assoc($result)) {
-  $services[] = $row;
-}
+ensurePromotionSupport($conn);
+
+$defaultStart = (new DateTimeImmutable('now'))->format('Y-m-d\TH:i');
+$defaultEnd = (new DateTimeImmutable('now +1 day'))->format('Y-m-d\TH:i');
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Add Promotion</title>
-</head>
+
 <body>
-  <?php include("header.php"); ?>
-  <?php include("slidebar.php"); ?>
+  <?php include 'header.php'; ?>
+  <?php include 'slidebar.php'; ?>
 
   <main id="main" class="main">
     <div class="pagetitle">
-      <h1>Add Promotion</h1>
+      <h1>เพิ่มโปรโมชั่น</h1>
     </div>
 
     <section class="section">
@@ -30,83 +24,42 @@ while ($row = mysqli_fetch_assoc($result)) {
         <div class="col-lg-12">
           <div class="card">
             <div class="card-body pt-4">
-              <form action="insert_promotion.php" method="POST">
+
+              <form id="promotionForm" data-promotion-form method="post" action="insert_promotion.php">
                 <div class="row g-3">
-
                   <div class="col-md-6">
-                    <div class="form-floating">
-                      <input type="text" name="pm_name" class="form-control" placeholder="Promotion Name" required>
-                      <label>Promotion Name</label>
-                    </div>
+                    <label class="form-label">ชื่อโปรโมชั่น</label>
+                    <input type="text" name="pm_name" class="form-control" placeholder="ระบุชื่อโปรโมชั่น" required>
                   </div>
-
-                  <div class="col-md-6">
-                    <div class="form-floating">
-                      <input type="number" name="discount" class="form-control" placeholder="Discount %" required>
-                      <label>Discount (%)</label>
-                    </div>
+                  <div class="col-md-3">
+                    <label class="form-label">วัน-เวลาเริ่มต้น</label>
+                    <input type="datetime-local" name="pm_start_date" class="form-control" value="<?= htmlspecialchars($defaultStart) ?>" required>
                   </div>
-
-                  <div class="col-md-6">
-                    <div class="form-floating">
-                      <input type="date" name="pm_start_date" class="form-control" required>
-                      <label>Start Date</label>
-                    </div>
+                  <div class="col-md-3">
+                    <label class="form-label">วัน-เวลาสิ้นสุด</label>
+                    <input type="datetime-local" name="pm_end_date" class="form-control" value="<?= htmlspecialchars($defaultEnd) ?>" required>
                   </div>
-
-                  <div class="col-md-6">
-                    <div class="form-floating">
-                      <input type="date" name="pm_end_date" class="form-control" required>
-                      <label>End Date</label>
-                    </div>
-                  </div>
-
-                  <div class="col-md-12">
-                    <label>Apply to all services?</label><br>
-                    <div class="form-check form-check-inline">
-                      <input class="form-check-input" type="radio" name="apply_to_all" id="applyYes" value="1" checked onclick="toggleServiceList(true)">
-                      <label class="form-check-label" for="applyYes">Yes</label>
-                    </div>
-                    <div class="form-check form-check-inline">
-                      <input class="form-check-input" type="radio" name="apply_to_all" id="applyNo" value="0" onclick="toggleServiceList(false)">
-                      <label class="form-check-label" for="applyNo">No</label>
-                    </div>
-                  </div>
-
-                  <div class="col-md-12 mt-2" id="serviceList" style="display: none;">
-                    <label>Select services for this promotion:</label>
-                    <?php foreach ($services as $service): ?>
-                      <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="service_ids[]" value="<?= $service['service_id'] ?>" id="service<?= $service['service_id'] ?>">
-                        <label class="form-check-label" for="service<?= $service['service_id'] ?>">
-                          <?= htmlspecialchars($service['service_name']) ?>
-                        </label>
-                      </div>
-                    <?php endforeach; ?>
-                  </div>
-
-                  <div class="col-md-12 mt-3">
-                    <div class="form-floating">
-                      <textarea name="description" class="form-control" style="height: 100px"></textarea>
-                      <label>Description</label>
-                    </div>
-                  </div>
-
-                  <div class="col-md-6">
-                    <label for="active" class="form-label">Status</label>
-                    <select name="active" id="active" class="form-select">
-                      <option value="1" selected>Active</option>
-                      <option value="0">Inactive</option>
-                    </select>
-                  </div>
-
                 </div>
 
-                <div class="text-center mt-4">
-                  <button type="submit" class="btn btn-primary">Add Promotion</button>
-                  <a href="promotion_table.php" class="btn btn-secondary">Cancel</a>
+                <div class="mt-4 d-flex justify-content-between align-items-center">
+                  <h5 class="mb-0">บริการที่เข้าร่วมโปรโมชั่น</h5>
+                  <button type="button" class="btn btn-primary" data-add-service><i class="bi bi-plus-lg"></i> เพิ่มบริการ</button>
+                </div>
+
+                <div class="alert alert-info mt-3" data-empty-state>
+                  กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุด จากนั้นคลิกปุ่ม "เพิ่มบริการ" เพื่อเลือกบริการที่ต้องการจัดโปรโมชั่น
+                </div>
+
+                <div class="row mt-3" data-selected-services></div>
+
+                <input type="hidden" name="promotion_payload" data-payload>
+
+                <div class="mt-4 text-center">
+                  <button type="submit" class="btn btn-success">บันทึกโปรโมชั่น</button>
+                  <a href="table_promotion.php" class="btn btn-secondary">ยกเลิก</a>
                 </div>
               </form>
+
             </div>
           </div>
         </div>
@@ -114,12 +67,46 @@ while ($row = mysqli_fetch_assoc($result)) {
     </section>
   </main>
 
-  <script>
-    function toggleServiceList(isAll) {
-      document.getElementById('serviceList').style.display = isAll ? 'none' : 'block';
-    }
-  </script>
+  <!-- Modal: Select services -->
+  <div class="modal fade" id="serviceSelectModal" tabindex="-1" aria-labelledby="serviceSelectModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="serviceSelectModalLabel">เลือกบริการเข้าร่วมโปรโมชั่น</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-warning d-none" data-modal-warning>
+            กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุดของโปรโมชั่นก่อนเลือกบริการ
+          </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="selectAllServices" data-select-all>
+            <label class="form-check-label" for="selectAllServices">เลือกทั้งหมด</label>
+          </div>
+          <div class="list-group" data-service-checkboxes></div>
+          <div class="text-muted mt-3 d-none" data-no-service>
+            ไม่พบบริการที่สามารถจัดโปรโมชั่นได้ในช่วงเวลานี้
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+          <button type="button" class="btn btn-primary" data-confirm-services>ยืนยัน</button>
+        </div>
+      </div>
+    </div>
+  </div>
 
-  <?php include("footer.php"); ?>
+  <script>
+    window.promotionFormConfig = {
+      availableServiceUrl: 'get_available_promotion_services.php',
+      optionsUrl: 'get_options.php',
+      promotionId: null,
+      initialServices: []
+    };
+  </script>
+  <script src="assets/js/promotion-form.js"></script>
+
+  <?php include 'footer.php'; ?>
 </body>
+
 </html>

--- a/Admin/get_applicable_promotions.php
+++ b/Admin/get_applicable_promotions.php
@@ -1,0 +1,40 @@
+<?php
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+
+if (!is_array($data)) {
+    echo json_encode(['success' => false, 'option_discounts' => [], 'promotions' => [], 'total_discount' => 0.0]);
+    exit;
+}
+
+$optionIds = isset($data['option_ids']) && is_array($data['option_ids']) ? array_map('intval', $data['option_ids']) : [];
+$dateValue = $data['date'] ?? '';
+$timeValue = $data['time'] ?? '';
+
+if (empty($optionIds) || empty($dateValue)) {
+    echo json_encode(['success' => true, 'option_discounts' => [], 'promotions' => [], 'total_discount' => 0.0]);
+    exit;
+}
+
+$target = combineDateAndTime($dateValue, $timeValue);
+if (!$target) {
+    echo json_encode(['success' => true, 'option_discounts' => [], 'promotions' => [], 'total_discount' => 0.0]);
+    exit;
+}
+
+ensurePromotionSupport($conn);
+$result = getApplicableOptionDiscounts($conn, $optionIds, $target);
+
+$response = [
+    'success' => true,
+    'option_discounts' => $result['by_option'],
+    'promotions' => $result['by_promotion'],
+    'total_discount' => $result['total_discount'],
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE);

--- a/Admin/get_available_promotion_services.php
+++ b/Admin/get_available_promotion_services.php
@@ -1,0 +1,25 @@
+<?php
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$startInput = $_GET['start'] ?? '';
+$endInput = $_GET['end'] ?? '';
+$promotionId = isset($_GET['promotion_id']) ? (int) $_GET['promotion_id'] : null;
+
+$start = parseDateTimeValue($startInput);
+$end = parseDateTimeValue($endInput);
+
+if (!$start || !$end || $end <= $start) {
+    echo json_encode([]);
+    exit;
+}
+
+$startString = $start->format('Y-m-d H:i:s');
+$endString = $end->format('Y-m-d H:i:s');
+
+ensurePromotionSupport($conn);
+$services = getAvailablePromotionServices($conn, $startString, $endString, $promotionId);
+
+echo json_encode($services, JSON_UNESCAPED_UNICODE);

--- a/Admin/get_promotions.php
+++ b/Admin/get_promotions.php
@@ -1,5 +1,25 @@
 <?php
-header('Content-Type: application/json');
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
+header('Content-Type: application/json; charset=utf-8');
 
-echo json_encode([]);
+$now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+
+$sql = "SELECT p.promotion_id, p.pm_name, p.pm_start_date, p.pm_end_date
+        FROM promotion p
+        WHERE p.pm_start_date <= ? AND p.pm_end_date >= ?
+        ORDER BY p.pm_start_date";
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('ss', $now, $now);
+$stmt->execute();
+$result = $stmt->get_result();
+
+$promotions = [];
+while ($row = $result->fetch_assoc()) {
+    $promotions[] = $row;
+}
+$stmt->close();
+
+echo json_encode($promotions, JSON_UNESCAPED_UNICODE);

--- a/Admin/insert_promotion.php
+++ b/Admin/insert_promotion.php
@@ -1,44 +1,156 @@
 <?php
-require_once("connect_db.php");
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
-// Get data from form
-$pm_name       = mysqli_real_escape_string($conn, $_POST['pm_name']);
-$description   = mysqli_real_escape_string($conn, $_POST['description']);
-$discount      = (float)$_POST['discount'];
-$apply_to_all  = (int)$_POST['apply_to_all'];
-$pm_start_date = $_POST['pm_start_date'];
-$pm_end_date   = $_POST['pm_end_date'];
-$active        = (int)$_POST['active'];
-$created_at    = date("Y-m-d H:i:s");
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถเพิ่มโปรโมชั่นได้')); 
+    exit;
+}
 
-// Insert into promotion table
-$sql = "INSERT INTO promotion (pm_name, description, discount, apply_to_all, pm_start_date, pm_end_date, active, pm_created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+ensurePromotionSupport($conn);
 
-$stmt = $conn->prepare($sql);
-$stmt->bind_param("ssdissis", $pm_name, $description, $discount, $apply_to_all, $pm_start_date, $pm_end_date, $active, $created_at);
+function redirectWithMessage(string $type, string $message): void
+{
+    header('Location: table_promotion.php?' . $type . '=' . urlencode($message));
+    exit;
+}
 
-if ($stmt->execute()) {
-    $promotion_id = $stmt->insert_id;
+$pmName = isset($_POST['pm_name']) ? trim($_POST['pm_name']) : '';
+$startInput = $_POST['pm_start_date'] ?? '';
+$endInput = $_POST['pm_end_date'] ?? '';
+$payloadJson = $_POST['promotion_payload'] ?? '';
 
-    // If apply_to_all = 0, insert selected services into promotion_service
-    if ($apply_to_all === 0 && !empty($_POST['service_ids'])) {
-        $service_ids = $_POST['service_ids'];
+if ($pmName === '' || $startInput === '' || $endInput === '' || $payloadJson === '') {
+    redirectWithMessage('error', 'กรุณากรอกข้อมูลให้ครบถ้วน');
+}
 
-        $psql = "INSERT INTO promotion_service (service_id, promotion_id) VALUES (?, ?)";
-        $pstmt = $conn->prepare($psql);
+$start = parseDateTimeValue($startInput);
+$end = parseDateTimeValue($endInput);
+if (!$start || !$end || $end <= $start) {
+    redirectWithMessage('error', 'กรุณาระบุวันและเวลาให้ถูกต้อง');
+}
 
-        foreach ($service_ids as $service_id) {
-            $sid = (int)$service_id;
-            $pstmt->bind_param("ii", $sid, $promotion_id);
-            $pstmt->execute();
+$payload = json_decode($payloadJson, true);
+if (!is_array($payload)) {
+    redirectWithMessage('error', 'ไม่สามารถอ่านข้อมูลบริการได้');
+}
+
+try {
+    $normalized = normalizePromotionPayload($conn, $payload);
+} catch (InvalidArgumentException $e) {
+    redirectWithMessage('error', $e->getMessage());
+}
+
+$services = $normalized['services'];
+$maxPercent = (float) $normalized['max_percent'];
+
+$serviceIds = array_map(static fn($service) => (int) $service['service_id'], $services);
+$startString = $start->format('Y-m-d H:i:s');
+$endString = $end->format('Y-m-d H:i:s');
+
+$conflicts = findConflictingServiceIds($conn, $serviceIds, $startString, $endString, null);
+if (!empty($conflicts)) {
+    redirectWithMessage('error', 'ไม่สามารถจัดโปรโมชั่นซ้ำกับบริการที่มีโปรโมชั่นในช่วงเวลาดังกล่าวได้');
+}
+
+$columns = getPromotionColumns($conn);
+if (!in_array('pm_name', $columns, true) || !in_array('pm_start_date', $columns, true) || !in_array('pm_end_date', $columns, true)) {
+    redirectWithMessage('error', 'โครงสร้างตารางโปรโมชั่นไม่รองรับการบันทึกข้อมูล');
+}
+
+$insertColumns = [];
+$types = '';
+$values = [];
+
+$insertColumns[] = 'pm_name';
+$types .= 's';
+$values[] = $pmName;
+
+if (in_array('description', $columns, true)) {
+    $insertColumns[] = 'description';
+    $types .= 's';
+    $values[] = '';
+}
+
+if (in_array('percent', $columns, true)) {
+    $insertColumns[] = 'percent';
+    $types .= 'd';
+    $values[] = $maxPercent;
+} elseif (in_array('discount', $columns, true)) {
+    $insertColumns[] = 'discount';
+    $types .= 'd';
+    $values[] = $maxPercent;
+}
+
+if (in_array('apply_to_all', $columns, true)) {
+    $insertColumns[] = 'apply_to_all';
+    $types .= 'i';
+    $values[] = 0;
+}
+
+$insertColumns[] = 'pm_start_date';
+$types .= 's';
+$values[] = $startString;
+
+$insertColumns[] = 'pm_end_date';
+$types .= 's';
+$values[] = $endString;
+
+if (in_array('active', $columns, true)) {
+    $insertColumns[] = 'active';
+    $types .= 'i';
+    $values[] = 1;
+}
+
+if (in_array('pm_created_at', $columns, true)) {
+    $insertColumns[] = 'pm_created_at';
+    $types .= 's';
+    $values[] = date('Y-m-d H:i:s');
+}
+
+$placeholders = implode(', ', array_fill(0, count($insertColumns), '?'));
+$sql = 'INSERT INTO promotion (' . implode(', ', $insertColumns) . ') VALUES (' . $placeholders . ')';
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        throw new RuntimeException('ไม่สามารถบันทึกโปรโมชั่นได้');
+    }
+    $stmt->bind_param($types, ...$values);
+    $stmt->execute();
+    $promotionId = $stmt->insert_id;
+    $stmt->close();
+
+    $serviceStmt = $conn->prepare('INSERT INTO promotion_service (service_id, promotion_id) VALUES (?, ?)');
+    $optionStmt = $conn->prepare('INSERT INTO promotion_service_option (promotion_id, service_id, option_id, discount_percent, discount_amount, final_price) VALUES (?, ?, ?, ?, ?, ?)');
+
+    if (!$serviceStmt || !$optionStmt) {
+        throw new RuntimeException('ไม่สามารถบันทึกข้อมูลบริการของโปรโมชั่นได้');
+    }
+
+    foreach ($services as $service) {
+        $serviceId = (int) $service['service_id'];
+        $serviceStmt->bind_param('ii', $serviceId, $promotionId);
+        $serviceStmt->execute();
+
+        foreach ($service['options'] as $option) {
+            $optionId = (int) $option['option_id'];
+            $percent = (float) $option['discount_percent'];
+            $discountAmount = (float) $option['discount_amount'];
+            $finalPrice = (float) $option['final_price'];
+
+            $optionStmt->bind_param('iiiddd', $promotionId, $serviceId, $optionId, $percent, $discountAmount, $finalPrice);
+            $optionStmt->execute();
         }
     }
 
-    // Redirect to promotion table page
-    header("Location: table_promotion.php");
-    exit;
-} else {
-    echo "Error: " . $stmt->error;
+    $serviceStmt->close();
+    $optionStmt->close();
+
+    $conn->commit();
+    redirectWithMessage('message', 'เพิ่มโปรโมชั่นเรียบร้อยแล้ว');
+} catch (Throwable $e) {
+    $conn->rollback();
+    redirectWithMessage('error', 'เกิดข้อผิดพลาดระหว่างบันทึกโปรโมชั่น');
 }
-?>

--- a/Admin/promotion_delete.php
+++ b/Admin/promotion_delete.php
@@ -1,0 +1,70 @@
+<?php
+session_start();
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบข้อมูลโปรโมชั่นที่ต้องการลบ'));
+    exit;
+}
+
+$promotionId = isset($_POST['promotion_id']) ? (int) $_POST['promotion_id'] : 0;
+if ($promotionId <= 0) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบข้อมูลโปรโมชั่นที่ต้องการลบ'));
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT pm_start_date, pm_end_date FROM promotion WHERE promotion_id = ?');
+if (!$stmt) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถตรวจสอบข้อมูลโปรโมชั่นได้'));
+    exit;
+}
+$stmt->bind_param('i', $promotionId);
+$stmt->execute();
+$result = $stmt->get_result();
+$promotion = $result->fetch_assoc();
+$stmt->close();
+
+if (!$promotion) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบข้อมูลโปรโมชั่นที่ต้องการลบ'));
+    exit;
+}
+
+$status = promotionStatus($promotion['pm_start_date'], $promotion['pm_end_date']);
+if ($status !== 'upcoming') {
+    header('Location: table_promotion.php?error=' . urlencode('สามารถลบได้เฉพาะโปรโมชั่นที่ยังไม่เริ่มเท่านั้น'));
+    exit;
+}
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare('DELETE FROM promotion_service_option WHERE promotion_id = ?');
+    if ($stmt) {
+        $stmt->bind_param('i', $promotionId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    $stmt = $conn->prepare('DELETE FROM promotion_service WHERE promotion_id = ?');
+    if ($stmt) {
+        $stmt->bind_param('i', $promotionId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    $stmt = $conn->prepare('DELETE FROM promotion WHERE promotion_id = ?');
+    if (!$stmt) {
+        throw new RuntimeException('ไม่สามารถลบโปรโมชั่นได้');
+    }
+    $stmt->bind_param('i', $promotionId);
+    $stmt->execute();
+    $stmt->close();
+
+    $conn->commit();
+    header('Location: table_promotion.php?message=' . urlencode('ลบโปรโมชั่นเรียบร้อยแล้ว'));
+    exit;
+} catch (Throwable $e) {
+    $conn->rollback();
+    header('Location: table_promotion.php?error=' . urlencode('เกิดข้อผิดพลาดในการลบโปรโมชั่น'));
+    exit;
+}

--- a/Admin/promotion_detail.php
+++ b/Admin/promotion_detail.php
@@ -1,137 +1,143 @@
 <?php
-require_once("connect_db.php");
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
-if (!isset($_GET['id'])) {
-  echo "No promotion ID provided.";
-  exit;
+$promotionId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($promotionId <= 0) {
+    echo 'ไม่พบข้อมูลโปรโมชั่น';
+    exit;
 }
 
-$promotion_id = intval($_GET['id']);
-
-// Get promotion details
-$stmt = $conn->prepare("SELECT * FROM promotion WHERE promotion_id = ?");
-$stmt->bind_param("i", $promotion_id);
+$stmt = $conn->prepare('SELECT * FROM promotion WHERE promotion_id = ?');
+$stmt->bind_param('i', $promotionId);
 $stmt->execute();
-$result = $stmt->get_result();
-$promotion = $result->fetch_assoc();
+$promotion = $stmt->get_result()->fetch_assoc();
+$stmt->close();
 
 if (!$promotion) {
-  echo "Promotion not found.";
-  exit;
+    echo 'ไม่พบข้อมูลโปรโมชั่น';
+    exit;
 }
 
-// Get related services
-$services = [];
-if (!$promotion['apply_to_all']) {
-  $stmt2 = $conn->prepare("
-    SELECT s.service_name 
-    FROM promotion_service ps 
-    JOIN service s ON ps.service_id = s.service_id 
-    WHERE ps.promotion_id = ?
-  ");
-  $stmt2->bind_param("i", $promotion_id);
-  $stmt2->execute();
-  $services_result = $stmt2->get_result();
-
-  while ($row = $services_result->fetch_assoc()) {
-    $services[] = $row['service_name'];
-  }
+$services = fetchPromotionServicesWithOptions($conn, $promotionId);
+$columns = getPromotionColumns($conn);
+$status = promotionStatus($promotion['pm_start_date'], $promotion['pm_end_date']);
+$maxPercent = 0.0;
+foreach ($services as $service) {
+    foreach ($service['options'] as $option) {
+        if ($option['discount_percent'] > $maxPercent) {
+            $maxPercent = $option['discount_percent'];
+        }
+    }
+}
+if ($maxPercent === 0.0) {
+    if (isset($promotion['percent'])) {
+        $maxPercent = (float) $promotion['percent'];
+    } elseif (isset($promotion['discount'])) {
+        $maxPercent = (float) $promotion['discount'];
+    }
 }
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <title>Promotion Detail</title>
-  <meta charset="UTF-8">
-  <link href="assets/css/style.css" rel="stylesheet">
-  <!-- Include your CSS and bootstrap here -->
-</head>
-
 <body>
+  <?php include 'header.php'; ?>
+  <?php include 'slidebar.php'; ?>
 
-<?php include("header.php"); ?>
-<?php include("slidebar.php"); ?>
+  <main id="main" class="main">
+    <div class="pagetitle">
+      <h1>รายละเอียดโปรโมชั่น</h1>
+    </div>
 
-<main id="main" class="main pt-5 mt-5">
+    <section class="section">
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body pt-4">
 
-  <div class="pagetitle">
-    <h1>Promotion Detail</h1>
-    <nav><ol class="breadcrumb"></ol></nav>
-  </div>
-
-  <section class="section">
-    <div class="row">
-      <div class="col-lg-12">
-
-        <div class="card">
-          <div class="card-body pt-4">
-
-            <!-- <h5 class="card-title">Promotion Information</h5> -->
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Name</label>
-              <div class="col-sm-9 pt-2"><?= htmlspecialchars($promotion['pm_name']) ?></div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Description</label>
-              <div class="col-sm-9 pt-2"><?= nl2br(htmlspecialchars($promotion['description'])) ?></div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Discount (%)</label>
-              <div class="col-sm-9 pt-2"><?= htmlspecialchars($promotion['discount']) ?>%</div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Apply to All Services</label>
-              <div class="col-sm-9 pt-2"><?= $promotion['apply_to_all'] ? 'Yes' : 'No' ?></div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Start Date</label>
-              <div class="col-sm-9 pt-2"><?= htmlspecialchars($promotion['pm_start_date']) ?></div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">End Date</label>
-              <div class="col-sm-9 pt-2"><?= htmlspecialchars($promotion['pm_end_date']) ?></div>
-            </div>
-
-            <div class="row mb-2">
-              <label class="col-sm-3 col-form-label">Status</label>
-              <div class="col-sm-9 pt-2"><?= $promotion['active'] ? 'Active' : 'Inactive' ?></div>
-            </div>
-
-            <?php if (!$promotion['apply_to_all']): ?>
-              <div class="row mt-4">
-                <label class="col-sm-3 col-form-label">Services</label>
-                <div class="col-sm-9">
-                  <ul class="list-group">
-                    <?php foreach ($services as $service): ?>
-                      <li class="list-group-item"><?= htmlspecialchars($service) ?></li>
-                    <?php endforeach; ?>
-                  </ul>
+              <div class="row mb-3">
+                <div class="col-md-6">
+                  <h5>ข้อมูลทั่วไป</h5>
+                  <dl class="row mb-0">
+                    <dt class="col-sm-4">ชื่อโปรโมชั่น</dt>
+                    <dd class="col-sm-8"><?= htmlspecialchars($promotion['pm_name'] ?? '-') ?></dd>
+                    <dt class="col-sm-4">วัน-เวลาเริ่มต้น</dt>
+                    <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_start_date'] ?? '')) ?></dd>
+                    <dt class="col-sm-4">วัน-เวลาสิ้นสุด</dt>
+                    <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_end_date'] ?? '')) ?></dd>
+                    <dt class="col-sm-4">สถานะ</dt>
+                    <dd class="col-sm-8"><?= htmlspecialchars(promotionStatusLabel($status)) ?></dd>
+                    <dt class="col-sm-4">ส่วนลดสูงสุด</dt>
+                    <dd class="col-sm-8"><?= number_format($maxPercent, 2) ?>%</dd>
+                    <?php if (in_array('pm_created_at', $columns, true) && !empty($promotion['pm_created_at'])): ?>
+                      <dt class="col-sm-4">สร้างเมื่อ</dt>
+                      <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_created_at'])) ?></dd>
+                    <?php endif; ?>
+                  </dl>
+                </div>
+                <div class="col-md-6">
+                  <h5>หมายเหตุ</h5>
+                  <?php if (!empty($promotion['description'])): ?>
+                    <p><?= nl2br(htmlspecialchars($promotion['description'])) ?></p>
+                  <?php else: ?>
+                    <p class="text-muted">ไม่มีรายละเอียดเพิ่มเติม</p>
+                  <?php endif; ?>
                 </div>
               </div>
-            <?php endif; ?>
 
-            <div class="text-center mt-4">
-              <a href="promotion_update_form.php?id=<?= $promotion['promotion_id'] ?>" class="btn btn-primary mt-3">Edit</a>
-              <a href="table_promotion.php" class="btn btn-secondary mt-3">Back</a>
+              <h5>บริการและส่วนลด</h5>
+              <?php if (empty($services)): ?>
+                <p class="text-muted">ไม่พบบริการในโปรโมชั่นนี้</p>
+              <?php else: ?>
+                <?php foreach ($services as $service): ?>
+                  <div class="card border mb-3">
+                    <div class="card-header bg-light fw-semibold">
+                      <?= htmlspecialchars($service['service_name']) ?>
+                    </div>
+                    <div class="card-body p-0">
+                      <div class="table-responsive">
+                        <table class="table table-bordered table-sm mb-0">
+                          <thead class="table-light">
+                            <tr>
+                              <th class="text-center" style="width: 120px;">ระยะเวลา (นาที)</th>
+                              <th class="text-end" style="width: 140px;">ราคาปกติ</th>
+                              <th class="text-center" style="width: 120px;">ส่วนลด (%)</th>
+                              <th class="text-end" style="width: 140px;">จำนวนส่วนลด</th>
+                              <th class="text-end" style="width: 140px;">ราคาหลังหัก</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <?php foreach ($service['options'] as $option): ?>
+                              <tr>
+                                <td class="text-center"><?= (int) $option['duration'] ?></td>
+                                <td class="text-end">฿<?= number_format((float) $option['price'], 2) ?></td>
+                                <td class="text-center"><?= number_format((float) $option['discount_percent'], 2) ?></td>
+                                <td class="text-end">฿<?= number_format((float) $option['discount_amount'], 2) ?></td>
+                                <td class="text-end">฿<?= number_format((float) $option['final_price'], 2) ?></td>
+                              </tr>
+                            <?php endforeach; ?>
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  </div>
+                <?php endforeach; ?>
+              <?php endif; ?>
+
+              <div class="mt-3 text-center">
+                <a href="promotion_update_form.php?id=<?= $promotionId ?>" class="btn btn-primary">แก้ไข</a>
+                <a href="table_promotion.php" class="btn btn-secondary">ย้อนกลับ</a>
+              </div>
+
             </div>
           </div>
         </div>
-
       </div>
-    </div>
-  </section>
+    </section>
+  </main>
 
-</main>
-
-<?php include("footer.php"); ?>
-
+  <?php include 'footer.php'; ?>
 </body>
+
 </html>

--- a/Admin/promotion_end.php
+++ b/Admin/promotion_end.php
@@ -1,0 +1,59 @@
+<?php
+session_start();
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบโปรโมชั่นที่ต้องการสิ้นสุด'));
+    exit;
+}
+
+$promotionId = isset($_POST['promotion_id']) ? (int) $_POST['promotion_id'] : 0;
+if ($promotionId <= 0) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบโปรโมชั่นที่ต้องการสิ้นสุด'));
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT pm_start_date, pm_end_date FROM promotion WHERE promotion_id = ?');
+if (!$stmt) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถตรวจสอบข้อมูลโปรโมชั่นได้'));
+    exit;
+}
+$stmt->bind_param('i', $promotionId);
+$stmt->execute();
+$result = $stmt->get_result();
+$promotion = $result->fetch_assoc();
+$stmt->close();
+
+if (!$promotion) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบโปรโมชั่นที่ต้องการสิ้นสุด'));
+    exit;
+}
+
+$status = promotionStatus($promotion['pm_start_date'], $promotion['pm_end_date']);
+if ($status !== 'running') {
+    header('Location: table_promotion.php?error=' . urlencode('สามารถสิ้นสุดได้เฉพาะโปรโมชั่นที่กำลังดำเนินการเท่านั้น'));
+    exit;
+}
+
+$now = (new DateTimeImmutable('now'))->format('Y-m-d H:i:s');
+$columns = getPromotionColumns($conn);
+$hasActive = in_array('active', $columns, true);
+
+if ($hasActive) {
+    $stmt = $conn->prepare('UPDATE promotion SET pm_end_date = ?, active = 0 WHERE promotion_id = ?');
+} else {
+    $stmt = $conn->prepare('UPDATE promotion SET pm_end_date = ? WHERE promotion_id = ?');
+}
+
+if (!$stmt) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถสิ้นสุดโปรโมชั่นได้'));
+    exit;
+}
+
+$stmt->bind_param('si', $now, $promotionId);
+$stmt->execute();
+$stmt->close();
+
+header('Location: table_promotion.php?message=' . urlencode('สิ้นสุดโปรโมชั่นเรียบร้อยแล้ว'));
+exit;

--- a/Admin/promotion_update.php
+++ b/Admin/promotion_update.php
@@ -1,43 +1,181 @@
 <?php
-require_once("connect_db.php");
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
-if (!isset($_GET['id'])) {
-    echo "No promotion ID provided.";
+$promotionId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($promotionId <= 0) {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่พบโปรโมชั่นที่ต้องการแก้ไข'));
     exit;
 }
 
-$promotion_id = intval($_GET['id']);
-
-// รับค่าจากฟอร์ม POST และป้องกัน SQL Injection
-$pm_name = mysqli_real_escape_string($conn, $_POST['pm_name']);
-$description = mysqli_real_escape_string($conn, $_POST['description']);
-$discount = floatval($_POST['discount']);
-$apply_to_all = isset($_POST['apply_to_all']) ? 1 : 0;
-$pm_start_date = $_POST['pm_start_date'];  // ควรอยู่ในรูปแบบ YYYY-MM-DD
-$pm_end_date = $_POST['pm_end_date'];      // ควรอยู่ในรูปแบบ YYYY-MM-DD
-$active = isset($_POST['active']) ? 1 : 0;
-
-// ตรวจสอบความถูกต้องเบื้องต้น เช่น วันที่เริ่มไม่เกินวันที่จบ
-if (strtotime($pm_start_date) > strtotime($pm_end_date)) {
-    echo "Start date cannot be later than end date.";
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถแก้ไขโปรโมชั่นได้'));
     exit;
 }
 
-// คำสั่ง SQL อัปเดต
-$sql = "UPDATE promotion SET 
-            pm_name = '$pm_name',
-            description = '$description',
-            discount = $discount,
-            apply_to_all = $apply_to_all,
-            pm_start_date = '$pm_start_date',
-            pm_end_date = '$pm_end_date',
-            active = $active
-        WHERE promotion_id = $promotion_id";
+ensurePromotionSupport($conn);
 
-if (mysqli_query($conn, $sql)) {
-    header("Location: table_promotion.php");  // เปลี่ยนเป็นหน้าที่แสดงตารางโปรโมชั่นของคุณ
+function redirectUpdate(string $type, string $message, int $promotionId): void
+{
+    header('Location: table_promotion.php?' . $type . '=' . urlencode($message));
     exit;
-} else {
-    echo "Error updating promotion: " . mysqli_error($conn);
 }
-?>
+
+$stmt = $conn->prepare('SELECT * FROM promotion WHERE promotion_id = ?');
+$stmt->bind_param('i', $promotionId);
+$stmt->execute();
+$currentPromotion = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+if (!$currentPromotion) {
+    redirectUpdate('error', 'ไม่พบโปรโมชั่นที่ต้องการแก้ไข', $promotionId);
+}
+
+$status = promotionStatus($currentPromotion['pm_start_date'], $currentPromotion['pm_end_date']);
+if ($status === 'ended') {
+    redirectUpdate('error', 'ไม่สามารถแก้ไขโปรโมชั่นที่สิ้นสุดแล้วได้', $promotionId);
+}
+
+$pmName = isset($_POST['pm_name']) ? trim($_POST['pm_name']) : '';
+$startInput = $_POST['pm_start_date'] ?? '';
+$endInput = $_POST['pm_end_date'] ?? '';
+$payloadJson = $_POST['promotion_payload'] ?? '';
+
+if ($pmName === '' || $startInput === '' || $endInput === '' || $payloadJson === '') {
+    redirectUpdate('error', 'กรุณากรอกข้อมูลให้ครบถ้วน', $promotionId);
+}
+
+$start = parseDateTimeValue($startInput);
+$end = parseDateTimeValue($endInput);
+if (!$start || !$end || $end <= $start) {
+    redirectUpdate('error', 'กรุณาระบุวันและเวลาให้ถูกต้อง', $promotionId);
+}
+
+$payload = json_decode($payloadJson, true);
+if (!is_array($payload)) {
+    redirectUpdate('error', 'ไม่สามารถอ่านข้อมูลบริการได้', $promotionId);
+}
+
+try {
+    $normalized = normalizePromotionPayload($conn, $payload);
+} catch (InvalidArgumentException $e) {
+    redirectUpdate('error', $e->getMessage(), $promotionId);
+}
+
+$services = $normalized['services'];
+$maxPercent = (float) $normalized['max_percent'];
+
+$serviceIds = array_map(static fn($service) => (int) $service['service_id'], $services);
+$startString = $start->format('Y-m-d H:i:s');
+$endString = $end->format('Y-m-d H:i:s');
+
+$conflicts = findConflictingServiceIds($conn, $serviceIds, $startString, $endString, $promotionId);
+if (!empty($conflicts)) {
+    redirectUpdate('error', 'ไม่สามารถจัดโปรโมชั่นซ้ำกับบริการที่มีโปรโมชั่นในช่วงเวลาดังกล่าวได้', $promotionId);
+}
+
+$columns = getPromotionColumns($conn);
+if (!in_array('pm_name', $columns, true) || !in_array('pm_start_date', $columns, true) || !in_array('pm_end_date', $columns, true)) {
+    redirectUpdate('error', 'โครงสร้างตารางโปรโมชั่นไม่รองรับการบันทึกข้อมูล', $promotionId);
+}
+
+$updateParts = [];
+$types = '';
+$values = [];
+
+$updateParts[] = 'pm_name = ?';
+$types .= 's';
+$values[] = $pmName;
+
+if (in_array('description', $columns, true)) {
+    $updateParts[] = 'description = ?';
+    $types .= 's';
+    $values[] = $currentPromotion['description'] ?? '';
+}
+
+if (in_array('percent', $columns, true)) {
+    $updateParts[] = 'percent = ?';
+    $types .= 'd';
+    $values[] = $maxPercent;
+} elseif (in_array('discount', $columns, true)) {
+    $updateParts[] = 'discount = ?';
+    $types .= 'd';
+    $values[] = $maxPercent;
+}
+
+if (in_array('apply_to_all', $columns, true)) {
+    $updateParts[] = 'apply_to_all = 0';
+}
+
+$updateParts[] = 'pm_start_date = ?';
+$types .= 's';
+$values[] = $startString;
+
+$updateParts[] = 'pm_end_date = ?';
+$types .= 's';
+$values[] = $endString;
+
+if (in_array('active', $columns, true)) {
+    $updateParts[] = 'active = 1';
+}
+
+$sql = 'UPDATE promotion SET ' . implode(', ', $updateParts) . ' WHERE promotion_id = ?';
+$types .= 'i';
+$values[] = $promotionId;
+
+$conn->begin_transaction();
+try {
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        throw new RuntimeException('ไม่สามารถบันทึกโปรโมชั่นได้');
+    }
+    $stmt->bind_param($types, ...$values);
+    $stmt->execute();
+    $stmt->close();
+
+    $deleteOptions = $conn->prepare('DELETE FROM promotion_service_option WHERE promotion_id = ?');
+    if ($deleteOptions) {
+        $deleteOptions->bind_param('i', $promotionId);
+        $deleteOptions->execute();
+        $deleteOptions->close();
+    }
+
+    $deleteServices = $conn->prepare('DELETE FROM promotion_service WHERE promotion_id = ?');
+    if ($deleteServices) {
+        $deleteServices->bind_param('i', $promotionId);
+        $deleteServices->execute();
+        $deleteServices->close();
+    }
+
+    $serviceStmt = $conn->prepare('INSERT INTO promotion_service (service_id, promotion_id) VALUES (?, ?)');
+    $optionStmt = $conn->prepare('INSERT INTO promotion_service_option (promotion_id, service_id, option_id, discount_percent, discount_amount, final_price) VALUES (?, ?, ?, ?, ?, ?)');
+
+    if (!$serviceStmt || !$optionStmt) {
+        throw new RuntimeException('ไม่สามารถบันทึกข้อมูลบริการของโปรโมชั่นได้');
+    }
+
+    foreach ($services as $service) {
+        $serviceId = (int) $service['service_id'];
+        $serviceStmt->bind_param('ii', $serviceId, $promotionId);
+        $serviceStmt->execute();
+
+        foreach ($service['options'] as $option) {
+            $optionId = (int) $option['option_id'];
+            $percent = (float) $option['discount_percent'];
+            $discountAmount = (float) $option['discount_amount'];
+            $finalPrice = (float) $option['final_price'];
+
+            $optionStmt->bind_param('iiiddd', $promotionId, $serviceId, $optionId, $percent, $discountAmount, $finalPrice);
+            $optionStmt->execute();
+        }
+    }
+
+    $serviceStmt->close();
+    $optionStmt->close();
+
+    $conn->commit();
+    redirectUpdate('message', 'บันทึกการแก้ไขโปรโมชั่นเรียบร้อยแล้ว', $promotionId);
+} catch (Throwable $e) {
+    $conn->rollback();
+    redirectUpdate('error', 'เกิดข้อผิดพลาดระหว่างบันทึกโปรโมชั่น', $promotionId);
+}

--- a/Admin/promotion_update.php
+++ b/Admin/promotion_update.php
@@ -174,7 +174,7 @@ try {
     $optionStmt->close();
 
     $conn->commit();
-    redirectUpdate('message', 'บันทึกการแก้ไขโปรโมชั่นเรียบร้อยแล้ว', $promotionId);
+    //redirectUpdate('message', 'บันทึกการแก้ไขโปรโมชั่นเรียบร้อยแล้ว', $promotionId);
 } catch (Throwable $e) {
     $conn->rollback();
     redirectUpdate('error', 'เกิดข้อผิดพลาดระหว่างบันทึกโปรโมชั่น', $promotionId);

--- a/Admin/promotion_update_form.php
+++ b/Admin/promotion_update_form.php
@@ -1,140 +1,152 @@
 <?php
-require_once("connect_db.php");
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
 
-if (!isset($_GET['id'])) {
-  echo "No promotion ID provided.";
-  exit;
+$promotionId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+if ($promotionId <= 0) {
+    echo 'ไม่พบโปรโมชั่นที่ต้องการแก้ไข';
+    exit;
 }
 
-$promotion_id = (int)$_GET['id'];
+ensurePromotionSupport($conn);
 
-// Get promotion
-$stmt = $conn->prepare("SELECT * FROM promotion WHERE promotion_id = ?");
-$stmt->bind_param("i", $promotion_id);
+$stmt = $conn->prepare('SELECT * FROM promotion WHERE promotion_id = ?');
+$stmt->bind_param('i', $promotionId);
 $stmt->execute();
 $promotion = $stmt->get_result()->fetch_assoc();
+$stmt->close();
 
 if (!$promotion) {
-  echo "Promotion not found.";
-  exit;
+    echo 'ไม่พบโปรโมชั่นที่ต้องการแก้ไข';
+    exit;
 }
 
-// Get all services
-$services = mysqli_query($conn, "SELECT * FROM service ORDER BY service_name ASC");
-
-// Get selected services (if not apply_to_all)
-$selected_services = [];
-if (!$promotion['apply_to_all']) {
-  $result = mysqli_query($conn, "SELECT service_id FROM promotion_service WHERE promotion_id = $promotion_id");
-  while ($row = mysqli_fetch_assoc($result)) {
-    $selected_services[] = $row['service_id'];
-  }
+$status = promotionStatus($promotion['pm_start_date'], $promotion['pm_end_date']);
+if ($status === 'ended') {
+    header('Location: table_promotion.php?error=' . urlencode('ไม่สามารถแก้ไขโปรโมชั่นที่สิ้นสุดแล้วได้'));
+    exit;
 }
 
-$pm_start_date = date('Y-m-d', strtotime($promotion['pm_start_date']));
-$pm_end_date = date('Y-m-d', strtotime($promotion['pm_end_date']));
+$startInputValue = parseDateTimeValue($promotion['pm_start_date']);
+$endInputValue = parseDateTimeValue($promotion['pm_end_date']);
+$startInputFormatted = $startInputValue ? $startInputValue->format('Y-m-d\TH:i') : '';
+$endInputFormatted = $endInputValue ? $endInputValue->format('Y-m-d\TH:i') : '';
+
+$services = fetchPromotionServicesWithOptions($conn, $promotionId);
+$initialServicesJson = json_encode($services, JSON_UNESCAPED_UNICODE);
+
+$columns = getPromotionColumns($conn);
+$currentPercent = 0.0;
+if (isset($promotion['percent'])) {
+    $currentPercent = (float) $promotion['percent'];
+} elseif (isset($promotion['discount'])) {
+    $currentPercent = (float) $promotion['discount'];
+}
 ?>
-
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <title>Edit Promotion</title>
-  <meta charset="UTF-8">
-  <link href="assets/css/style.css" rel="stylesheet">
-</head>
-
 <body>
+  <?php include 'header.php'; ?>
+  <?php include 'slidebar.php'; ?>
 
-<?php include("header.php"); ?>
-<?php include("slidebar.php"); ?>
+  <main id="main" class="main">
+    <div class="pagetitle">
+      <h1>แก้ไขโปรโมชั่น</h1>
+    </div>
 
-<main id="main" class="main">
-  <div class="pagetitle">
-    <h1>Edit Promotion</h1>
-    <nav><ol class="breadcrumb"></ol></nav>
-  </div>
+    <section class="section">
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body pt-4">
 
-  <section class="section">
-    <div class="row">
-      <div class="col-lg-10">
-
-        <div class="card">
-          <div class="card-body pt-4">
-            <form action="promotion_update.php?id=<?= $promotion_id ?>" method="post">
-
-              <div class="mb-3">
-                <label class="form-label">Promotion Name</label>
-                <input type="text" class="form-control" name="pm_name" value="<?= htmlspecialchars($promotion['pm_name']) ?>" required>
-              </div>
-
-              <div class="mb-3">
-                <label class="form-label">Description</label>
-                <textarea class="form-control" name="description" rows="3"><?= htmlspecialchars($promotion['description']) ?></textarea>
-              </div>
-
-              <div class="mb-3">
-                <label class="form-label">Discount (%)</label>
-                <input type="number" class="form-control" name="discount" value="<?= $promotion['discount'] ?>" min="0" max="100" required>
-              </div>
-
-              <div class="form-check form-switch mb-3">
-                <input class="form-check-input" type="checkbox" name="apply_to_all" id="applyToAll" <?= $promotion['apply_to_all'] ? 'checked' : '' ?>>
-                <label class="form-check-label" for="applyToAll">Apply to All Services</label>
-              </div>
-
-              <div class="mb-3" id="servicesList" <?= $promotion['apply_to_all'] ? 'style="display:none;"' : '' ?>>
-                <label class="form-label">Select Services</label>
-                <div class="row">
-                  <?php while ($service = mysqli_fetch_assoc($services)) { ?>
-                    <div class="col-md-4">
-                      <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="service_ids[]" value="<?= $service['service_id'] ?>"
-                          <?= in_array($service['service_id'], $selected_services) ? 'checked' : '' ?>>
-                        <label class="form-check-label"><?= htmlspecialchars($service['service_name']) ?></label>
-                      </div>
-                    </div>
-                  <?php } ?>
+              <form id="promotionForm" data-promotion-form method="post" action="promotion_update.php?id=<?= $promotionId ?>">
+                <div class="row g-3">
+                  <div class="col-md-6">
+                    <label class="form-label">ชื่อโปรโมชั่น</label>
+                    <input type="text" name="pm_name" class="form-control" value="<?= htmlspecialchars($promotion['pm_name'] ?? '') ?>" required>
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label">วัน-เวลาเริ่มต้น</label>
+                    <input type="datetime-local" name="pm_start_date" class="form-control" value="<?= htmlspecialchars($startInputFormatted) ?>" required>
+                  </div>
+                  <div class="col-md-3">
+                    <label class="form-label">วัน-เวลาสิ้นสุด</label>
+                    <input type="datetime-local" name="pm_end_date" class="form-control" value="<?= htmlspecialchars($endInputFormatted) ?>" required>
+                  </div>
                 </div>
-              </div>
 
-
-              <div class="row mb-3">
-                <div class="col">
-                  <label class="form-label">Start Date</label>
-                  <input type="date" class="form-control" name="pm_start_date" value="<?= $pm_start_date ?>" required>
+                <div class="mt-2 text-muted">
+                  สถานะปัจจุบัน: <strong><?= htmlspecialchars(promotionStatusLabel($status)) ?></strong>
                 </div>
-                <div class="col">
-                  <label class="form-label">End Date</label>
-                 <input type="date" class="form-control" name="pm_end_date" value="<?= $pm_end_date ?>" required>
+
+                <div class="mt-4 d-flex justify-content-between align-items-center">
+                  <h5 class="mb-0">บริการที่เข้าร่วมโปรโมชั่น</h5>
+                  <button type="button" class="btn btn-primary" data-add-service><i class="bi bi-plus-lg"></i> เพิ่มบริการ</button>
                 </div>
-              </div>
 
-              <div class="form-check form-switch mb-4">
-                <input class="form-check-input" type="checkbox" name="active" id="activeSwitch" <?= $promotion['active'] ? 'checked' : '' ?>>
-                <label class="form-check-label" for="activeSwitch">Active</label>
-              </div>
+                <div class="alert alert-info mt-3 d-none" data-empty-state>
+                  กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุด จากนั้นคลิกปุ่ม "เพิ่มบริการ" เพื่อเลือกบริการที่ต้องการจัดโปรโมชั่น
+                </div>
 
-              <div class="text-center mt-4">
-                <button type="submit" class="btn btn-primary">Update Promotion</button>
-                <a href="table_promotion.php" class="btn btn-secondary">Cancel</a>
-              </div>
+                <div class="row mt-3" data-selected-services></div>
 
-            </form>
+                <input type="hidden" name="promotion_payload" data-payload>
+
+                <div class="mt-4 text-center">
+                  <button type="submit" class="btn btn-success">บันทึกการแก้ไข</button>
+                  <a href="table_promotion.php" class="btn btn-secondary">ยกเลิก</a>
+                </div>
+              </form>
+
+            </div>
           </div>
         </div>
+      </div>
+    </section>
+  </main>
 
+  <!-- Modal same as in add form -->
+  <div class="modal fade" id="serviceSelectModal" tabindex="-1" aria-labelledby="serviceSelectModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="serviceSelectModalLabel">เลือกบริการเข้าร่วมโปรโมชั่น</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-warning d-none" data-modal-warning>
+            กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุดของโปรโมชั่นก่อนเลือกบริการ
+          </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="selectAllServices" data-select-all>
+            <label class="form-check-label" for="selectAllServices">เลือกทั้งหมด</label>
+          </div>
+          <div class="list-group" data-service-checkboxes></div>
+          <div class="text-muted mt-3 d-none" data-no-service>
+            ไม่พบบริการที่สามารถจัดโปรโมชั่นได้ในช่วงเวลานี้
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
+          <button type="button" class="btn btn-primary" data-confirm-services>ยืนยัน</button>
+        </div>
       </div>
     </div>
-  </section>
-</main>
+  </div>
 
-<script>
-document.getElementById("applyToAll").addEventListener("change", function() {
-  document.getElementById("servicesList").style.display = this.checked ? "none" : "block";
-});
-</script>
+  <script>
+    window.promotionFormConfig = {
+      availableServiceUrl: 'get_available_promotion_services.php',
+      optionsUrl: 'get_options.php',
+      promotionId: <?= $promotionId ?>,
+      initialServices: <?= $initialServicesJson ?: '[]' ?>
+    };
+  </script>
+  <script src="assets/js/promotion-form.js"></script>
 
-<?php include("footer.php"); ?>
+  <?php include 'footer.php'; ?>
 </body>
+
 </html>

--- a/Admin/promotion_utils.php
+++ b/Admin/promotion_utils.php
@@ -1,0 +1,591 @@
+<?php
+/**
+ * Helper functions for managing promotion logic.
+ */
+
+if (!function_exists('getPromotionColumns')) {
+    function getPromotionColumns(mysqli $conn): array
+    {
+        $columns = [];
+        if ($result = $conn->query("SHOW COLUMNS FROM promotion")) {
+            while ($row = $result->fetch_assoc()) {
+                $columns[] = $row['Field'];
+            }
+            $result->free();
+        }
+        return $columns;
+    }
+}
+
+if (!function_exists('ensurePromotionSupport')) {
+    function ensurePromotionSupport(mysqli $conn): void
+    {
+        $conn->query(
+            "CREATE TABLE IF NOT EXISTS promotion_service (
+                pm_service_id INT AUTO_INCREMENT PRIMARY KEY,
+                service_id INT NOT NULL,
+                promotion_id INT NOT NULL,
+                UNIQUE KEY uniq_promotion_service (service_id, promotion_id)
+            )"
+        );
+
+        $conn->query(
+            "CREATE TABLE IF NOT EXISTS promotion_service_option (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                promotion_id INT NOT NULL,
+                service_id INT NOT NULL,
+                option_id INT NOT NULL,
+                discount_percent DECIMAL(6,2) NOT NULL DEFAULT 0,
+                discount_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+                final_price DECIMAL(10,2) NOT NULL DEFAULT 0,
+                is_active TINYINT(1) NOT NULL DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE KEY uniq_promotion_option (promotion_id, option_id)
+            )"
+        );
+    }
+}
+
+if (!function_exists('parseDateTimeValue')) {
+    function parseDateTimeValue(?string $value): ?DateTimeImmutable
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        $formats = [
+            'Y-m-d\TH:i',
+            'Y-m-d H:i:s',
+            'Y-m-d H:i',
+            DateTimeInterface::ATOM,
+        ];
+
+        foreach ($formats as $format) {
+            $dt = DateTimeImmutable::createFromFormat($format, $value);
+            if ($dt instanceof DateTimeImmutable) {
+                return $dt;
+            }
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+}
+
+if (!function_exists('promotionStatus')) {
+    function promotionStatus(string $start, string $end, ?DateTimeImmutable $now = null): string
+    {
+        $now = $now ?: new DateTimeImmutable('now');
+        $startDt = parseDateTimeValue($start);
+        $endDt = parseDateTimeValue($end);
+
+        if (!$startDt || !$endDt) {
+            return 'unknown';
+        }
+
+        if ($now < $startDt) {
+            return 'upcoming';
+        }
+
+        if ($now > $endDt) {
+            return 'ended';
+        }
+
+        return 'running';
+    }
+}
+
+if (!function_exists('promotionStatusLabel')) {
+    function promotionStatusLabel(string $status): string
+    {
+        return match ($status) {
+            'upcoming' => 'ยังไม่เริ่ม',
+            'running' => 'กำลังดำเนินการ',
+            'ended' => 'สิ้นสุด',
+            default => 'ไม่ทราบ',
+        };
+    }
+}
+
+if (!function_exists('formatDateTimeDisplay')) {
+    function formatDateTimeDisplay(?string $value): string
+    {
+        $dt = parseDateTimeValue($value);
+        return $dt ? $dt->format('Y-m-d H:i') : '-';
+    }
+}
+
+if (!function_exists('findConflictingServiceIds')) {
+    function findConflictingServiceIds(mysqli $conn, array $serviceIds, string $start, string $end, ?int $excludePromotionId = null): array
+    {
+        if (empty($serviceIds)) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($serviceIds), '?'));
+        $sql = "SELECT DISTINCT ps.service_id
+                FROM promotion_service ps
+                INNER JOIN promotion p ON p.promotion_id = ps.promotion_id
+                WHERE ps.service_id IN ($placeholders)
+                  AND p.pm_start_date <= ?
+                  AND p.pm_end_date >= ?";
+
+        $types = str_repeat('i', count($serviceIds)) . 'ss';
+        $params = array_values($serviceIds);
+        $params[] = $end;
+        $params[] = $start;
+
+        if ($excludePromotionId) {
+            $sql .= " AND ps.promotion_id <> ?";
+            $types .= 'i';
+            $params[] = $excludePromotionId;
+        }
+
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            return [];
+        }
+
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $conflicts = [];
+        while ($row = $result->fetch_assoc()) {
+            $conflicts[] = (int)$row['service_id'];
+        }
+        $stmt->close();
+
+        return $conflicts;
+    }
+}
+
+if (!function_exists('getAvailablePromotionServices')) {
+    function getAvailablePromotionServices(mysqli $conn, string $start, string $end, ?int $promotionId = null): array
+    {
+        $services = [];
+        $sql = "SELECT service_id, service_name
+                FROM service
+                WHERE is_active = 1
+                ORDER BY service_name";
+
+        if ($result = $conn->query($sql)) {
+            while ($row = $result->fetch_assoc()) {
+                $services[(int)$row['service_id']] = [
+                    'service_id' => (int)$row['service_id'],
+                    'service_name' => $row['service_name'],
+                ];
+            }
+            $result->free();
+        }
+
+        if (empty($services)) {
+            return [];
+        }
+
+        $conflicts = findConflictingServiceIds($conn, array_keys($services), $start, $end, $promotionId);
+        foreach ($conflicts as $conflictId) {
+            unset($services[$conflictId]);
+        }
+
+        return array_values($services);
+    }
+}
+
+if (!function_exists('normalizePromotionPayload')) {
+    function normalizePromotionPayload(mysqli $conn, array $payload): array
+    {
+        if (empty($payload)) {
+            throw new InvalidArgumentException('กรุณาเลือกบริการอย่างน้อย 1 รายการ');
+        }
+
+        $serviceIds = [];
+        $optionIds = [];
+        foreach ($payload as $service) {
+            if (!is_array($service) || !isset($service['service_id'])) {
+                continue;
+            }
+            $sid = (int) $service['service_id'];
+            if ($sid <= 0) {
+                continue;
+            }
+            $serviceIds[$sid] = $sid;
+            if (empty($service['options']) || !is_array($service['options'])) {
+                throw new InvalidArgumentException('บริการที่เลือกต้องมี option อย่างน้อย 1 รายการ');
+            }
+            foreach ($service['options'] as $option) {
+                if (!is_array($option) || !isset($option['option_id'])) {
+                    continue;
+                }
+                $oid = (int) $option['option_id'];
+                if ($oid <= 0) {
+                    continue;
+                }
+                $optionIds[$oid] = $oid;
+            }
+        }
+
+        if (empty($serviceIds) || empty($optionIds)) {
+            throw new InvalidArgumentException('ข้อมูลบริการหรือ option ไม่ถูกต้อง');
+        }
+
+        // Fetch services
+        $placeholders = implode(',', array_fill(0, count($serviceIds), '?'));
+        $types = str_repeat('i', count($serviceIds));
+        $stmt = $conn->prepare("SELECT service_id, service_name FROM service WHERE service_id IN ($placeholders)");
+        if (!$stmt) {
+            throw new InvalidArgumentException('ไม่สามารถตรวจสอบข้อมูลบริการได้');
+        }
+        $stmt->bind_param($types, ...array_values($serviceIds));
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $serviceMap = [];
+        while ($row = $result->fetch_assoc()) {
+            $serviceMap[(int)$row['service_id']] = $row['service_name'];
+        }
+        $stmt->close();
+
+        if (count($serviceMap) !== count($serviceIds)) {
+            throw new InvalidArgumentException('พบบริการที่ไม่สามารถใช้งานได้ กรุณาตรวจสอบใหม่');
+        }
+
+        // Fetch options
+        $placeholders = implode(',', array_fill(0, count($optionIds), '?'));
+        $types = str_repeat('i', count($optionIds));
+        $stmt = $conn->prepare(
+            "SELECT option_id, service_id, duration, price
+             FROM service_option
+             WHERE option_id IN ($placeholders)"
+        );
+        if (!$stmt) {
+            throw new InvalidArgumentException('ไม่สามารถตรวจสอบข้อมูล option ได้');
+        }
+        $stmt->bind_param($types, ...array_values($optionIds));
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $optionMap = [];
+        while ($row = $result->fetch_assoc()) {
+            $optionMap[(int)$row['option_id']] = [
+                'service_id' => (int)$row['service_id'],
+                'duration' => (int)$row['duration'],
+                'price' => (float)$row['price'],
+            ];
+        }
+        $stmt->close();
+
+        if (count($optionMap) !== count($optionIds)) {
+            throw new InvalidArgumentException('พบ option ที่ไม่สามารถใช้งานได้ กรุณาตรวจสอบใหม่');
+        }
+
+        $normalized = [];
+        $maxPercent = 0.0;
+
+        foreach ($payload as $service) {
+            $sid = isset($service['service_id']) ? (int)$service['service_id'] : 0;
+            if ($sid <= 0 || !isset($serviceMap[$sid])) {
+                continue;
+            }
+
+            $serviceEntry = [
+                'service_id' => $sid,
+                'service_name' => $serviceMap[$sid],
+                'options' => [],
+            ];
+
+            foreach ($service['options'] as $option) {
+                $oid = isset($option['option_id']) ? (int)$option['option_id'] : 0;
+                if ($oid <= 0 || !isset($optionMap[$oid])) {
+                    continue;
+                }
+                $meta = $optionMap[$oid];
+                if ($meta['service_id'] !== $sid) {
+                    throw new InvalidArgumentException('มี option ที่ไม่ตรงกับบริการที่เลือก');
+                }
+                $percent = isset($option['discount_percent']) ? (float)$option['discount_percent'] : 0.0;
+                if ($percent < 0 || $percent > 100) {
+                    throw new InvalidArgumentException('เปอร์เซ็นต์ส่วนลดต้องอยู่ระหว่าง 0-100');
+                }
+
+                $discountAmount = round($meta['price'] * $percent / 100, 2);
+                $finalPrice = round($meta['price'] - $discountAmount, 2);
+
+                $serviceEntry['options'][] = [
+                    'option_id' => $oid,
+                    'duration' => $meta['duration'],
+                    'price' => $meta['price'],
+                    'discount_percent' => $percent,
+                    'discount_amount' => $discountAmount,
+                    'final_price' => $finalPrice,
+                ];
+
+                if ($percent > $maxPercent) {
+                    $maxPercent = $percent;
+                }
+            }
+
+            if (empty($serviceEntry['options'])) {
+                throw new InvalidArgumentException('บริการแต่ละรายการต้องมี option ที่ร่วมโปรโมชั่นอย่างน้อย 1 รายการ');
+            }
+
+            $normalized[] = $serviceEntry;
+        }
+
+        if (empty($normalized)) {
+            throw new InvalidArgumentException('ไม่พบข้อมูลบริการที่ถูกต้อง');
+        }
+
+        return [
+            'services' => $normalized,
+            'max_percent' => $maxPercent,
+        ];
+    }
+}
+
+if (!function_exists('fetchPromotionServicesWithOptions')) {
+    function fetchPromotionServicesWithOptions(mysqli $conn, int $promotionId): array
+    {
+        $sql = "SELECT ps.service_id, s.service_name,
+                       pso.option_id, pso.discount_percent, pso.discount_amount, pso.final_price,
+                       so.duration, so.price
+                FROM promotion_service ps
+                INNER JOIN service s ON s.service_id = ps.service_id
+                LEFT JOIN promotion_service_option pso
+                       ON pso.promotion_id = ps.promotion_id AND pso.service_id = ps.service_id
+                LEFT JOIN service_option so ON so.option_id = pso.option_id
+                WHERE ps.promotion_id = ?
+                ORDER BY s.service_name, so.duration";
+
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            return [];
+        }
+        $stmt->bind_param('i', $promotionId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $services = [];
+        while ($row = $result->fetch_assoc()) {
+            $sid = (int) $row['service_id'];
+            if (!isset($services[$sid])) {
+                $services[$sid] = [
+                    'service_id' => $sid,
+                    'service_name' => $row['service_name'],
+                    'options' => [],
+                ];
+            }
+
+            if (!empty($row['option_id'])) {
+                $services[$sid]['options'][(int) $row['option_id']] = [
+                    'option_id' => (int) $row['option_id'],
+                    'discount_percent' => (float) $row['discount_percent'],
+                    'discount_amount' => (float) $row['discount_amount'],
+                    'final_price' => (float) $row['final_price'],
+                    'duration' => isset($row['duration']) ? (int) $row['duration'] : 0,
+                    'price' => isset($row['price']) ? (float) $row['price'] : 0.0,
+                    'included' => true,
+                ];
+            }
+        }
+        $stmt->close();
+
+        if (empty($services)) {
+            return [];
+        }
+
+        $serviceIds = array_keys($services);
+        $placeholders = implode(',', array_fill(0, count($serviceIds), '?'));
+        $types = str_repeat('i', count($serviceIds));
+        $optStmt = $conn->prepare("SELECT option_id, service_id, duration, price FROM service_option WHERE service_id IN ($placeholders) ORDER BY duration");
+        if ($optStmt) {
+            $optStmt->bind_param($types, ...$serviceIds);
+            $optStmt->execute();
+            $optResult = $optStmt->get_result();
+            while ($opt = $optResult->fetch_assoc()) {
+                $sid = (int) $opt['service_id'];
+                if (!isset($services[$sid])) {
+                    continue;
+                }
+                $optionId = (int) $opt['option_id'];
+                if (!isset($services[$sid]['options'][$optionId])) {
+                    $services[$sid]['options'][$optionId] = [
+                        'option_id' => $optionId,
+                        'discount_percent' => 0.0,
+                        'discount_amount' => 0.0,
+                        'final_price' => (float) $opt['price'],
+                        'duration' => (int) $opt['duration'],
+                        'price' => (float) $opt['price'],
+                        'included' => false,
+                    ];
+                } else {
+                    $services[$sid]['options'][$optionId]['duration'] = (int) $opt['duration'];
+                    $services[$sid]['options'][$optionId]['price'] = (float) $opt['price'];
+                    if (!$services[$sid]['options'][$optionId]['final_price']) {
+                        $services[$sid]['options'][$optionId]['final_price'] = (float) $opt['price'];
+                    }
+                    if (!isset($services[$sid]['options'][$optionId]['included'])) {
+                        $services[$sid]['options'][$optionId]['included'] = true;
+                    }
+                }
+            }
+            $optStmt->close();
+        }
+
+        foreach ($services as &$service) {
+            $service['options'] = array_values($service['options']);
+        }
+        unset($service);
+
+        return array_values($services);
+    }
+}
+
+if (!function_exists('combineDateAndTime')) {
+    function combineDateAndTime(string $date, ?string $time): ?string
+    {
+        $date = trim($date);
+        $time = $time !== null ? trim($time) : '';
+        if ($date === '') {
+            return null;
+        }
+
+        $format = 'Y-m-d';
+        $dt = DateTimeImmutable::createFromFormat($format, $date);
+        if (!$dt) {
+            return null;
+        }
+
+        if ($time === '') {
+            $time = '00:00';
+        }
+
+        $dateTimeString = $dt->format('Y-m-d') . ' ' . $time;
+        $combined = parseDateTimeValue($dateTimeString);
+        return $combined ? $combined->format('Y-m-d H:i:s') : null;
+    }
+}
+
+if (!function_exists('getApplicableOptionDiscounts')) {
+    function getApplicableOptionDiscounts(mysqli $conn, array $optionIds, string $targetDateTime): array
+    {
+        if (empty($optionIds)) {
+            return [
+                'by_option' => [],
+                'by_promotion' => [],
+                'total_discount' => 0.0,
+            ];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($optionIds), '?'));
+        $types = str_repeat('i', count($optionIds)) . 'ss';
+
+        $sql = "SELECT p.promotion_id, p.pm_name, p.pm_start_date, p.pm_end_date,
+                       pso.option_id, pso.discount_percent, pso.discount_amount, pso.final_price,
+                       s.service_id, s.service_name,
+                       so.duration, so.price
+                FROM promotion_service_option pso
+                INNER JOIN promotion p ON p.promotion_id = pso.promotion_id
+                INNER JOIN service_option so ON so.option_id = pso.option_id
+                INNER JOIN service s ON s.service_id = pso.service_id
+                WHERE pso.option_id IN ($placeholders)
+                  AND IFNULL(pso.is_active, 1) = 1
+                  AND p.pm_start_date <= ?
+                  AND p.pm_end_date >= ?";
+
+        $params = array_values($optionIds);
+        $params[] = $targetDateTime;
+        $params[] = $targetDateTime;
+
+        $stmt = $conn->prepare($sql);
+        if (!$stmt) {
+            return [
+                'by_option' => [],
+                'by_promotion' => [],
+                'total_discount' => 0.0,
+            ];
+        }
+
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $byOption = [];
+        while ($row = $result->fetch_assoc()) {
+            $optionId = (int) $row['option_id'];
+            $percent = (float) $row['discount_percent'];
+            $discountAmount = (float) $row['discount_amount'];
+            $finalPrice = (float) $row['final_price'];
+            $price = (float) $row['price'];
+
+            if (!isset($byOption[$optionId]) || $percent > $byOption[$optionId]['discount_percent']) {
+                $byOption[$optionId] = [
+                    'promotion_id' => (int) $row['promotion_id'],
+                    'promotion_name' => $row['pm_name'],
+                    'service_id' => (int) $row['service_id'],
+                    'service_name' => $row['service_name'],
+                    'duration' => (int) $row['duration'],
+                    'price' => $price,
+                    'discount_percent' => $percent,
+                    'discount_amount' => $discountAmount,
+                    'final_price' => $finalPrice ?: max($price - $discountAmount, 0),
+                ];
+            }
+        }
+        $stmt->close();
+
+        $byPromotion = [];
+        $totalDiscount = 0.0;
+        foreach ($byOption as $optionId => $info) {
+            $promotionId = $info['promotion_id'];
+            if (!isset($byPromotion[$promotionId])) {
+                $byPromotion[$promotionId] = [
+                    'promotion_id' => $promotionId,
+                    'promotion_name' => $info['promotion_name'],
+                    'options' => [],
+                    'total_discount' => 0.0,
+                ];
+            }
+            $byPromotion[$promotionId]['options'][] = [
+                'option_id' => $optionId,
+                'service_name' => $info['service_name'],
+                'duration' => $info['duration'],
+                'price' => $info['price'],
+                'discount_percent' => $info['discount_percent'],
+                'discount_amount' => $info['discount_amount'],
+                'final_price' => $info['final_price'],
+            ];
+            $byPromotion[$promotionId]['total_discount'] += $info['discount_amount'];
+            $totalDiscount += $info['discount_amount'];
+        }
+
+        return [
+            'by_option' => $byOption,
+            'by_promotion' => array_values($byPromotion),
+            'total_discount' => $totalDiscount,
+        ];
+    }
+}
+
+if (!function_exists('summarizePromotionDiscountDetail')) {
+    function summarizePromotionDiscountDetail(array $promotions): string
+    {
+        if (empty($promotions)) {
+            return '';
+        }
+
+        $lines = [];
+        foreach ($promotions as $promotion) {
+            $lines[] = ($promotion['promotion_name'] ?? 'Promotion') . ':';
+            if (!empty($promotion['options'])) {
+                foreach ($promotion['options'] as $option) {
+                    $label = ($option['service_name'] ?? 'Service') . ' ' . ($option['duration'] ?? '-') . ' นาที';
+                    $discount = number_format((float) ($option['discount_amount'] ?? 0), 2);
+                    $lines[] = "- {$label} ลด ฿{$discount}";
+                }
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/Admin/slidebar.php
+++ b/Admin/slidebar.php
@@ -53,6 +53,13 @@ $isAdmin2 = isset($_SESSION['staff_level']) && $_SESSION['staff_level'] === 'sta
         </a>
       </li>
 
+      <li class="nav-item">
+        <a class="nav-link collapsed<?php if ($current_page == 'table_promotion.php') echo ' active'; ?>" href="table_promotion.php">
+          <i class="bi bi-layout-text-window-reverse"></i>
+          <span>Promotion Data</span>
+        </a>
+      </li>
+
       <li class="nav-item">       
           <a> <span>Reports</span> </a>
       </li>

--- a/Admin/submit_booking.php
+++ b/Admin/submit_booking.php
@@ -1,87 +1,117 @@
 <?php
-$pdo = new PDO("mysql:host=127.0.0.1;dbname=first9", "root", "");
-$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION); // Enable PDO exceptions
+require_once 'promotion_utils.php';
+require_once 'connect_db.php';
+
+$pdo = new PDO('mysql:host=127.0.0.1;dbname=first9', 'root', '');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $pdo->beginTransaction();
 
 try {
-    $customer_id = $_POST['customer_id'];; // Example: Hardcoded for demo; replace with authenticated user ID
-    $staff_id = $_POST['staff_id'];
-    $booking_date = $_POST['booking_date'];
-    $start_time = $_POST['start_time'];
-    $services = $_POST['services'];
-    $options = $_POST['options'];
-    $targetDir = "assets/img/";
+    $customer_id = (int) ($_POST['customer_id'] ?? 0);
+    $staff_id = (int) ($_POST['staff_id'] ?? 0);
+    $booking_date = $_POST['booking_date'] ?? '';
+    $start_time = $_POST['start_time'] ?? '';
+    $services = $_POST['services'] ?? [];
+    $options = $_POST['options'] ?? [];
+    $targetDir = 'assets/img/';
 
-    // File upload handling
-    $evidence_image = "no_image.jpg"; // Default value for evidence column
-    if (isset($_FILES["imgprofile"]) && $_FILES["imgprofile"]["error"] == 0) {
-        $fileName = basename($_FILES["imgprofile"]["name"]);
-        $targetFilePath = $targetDir . uniqid() . '_' . $fileName; // Add uniqid to prevent file name conflicts
+    if ($customer_id <= 0 || $staff_id <= 0 || empty($booking_date) || empty($start_time) || empty($options)) {
+        throw new Exception('กรุณากรอกข้อมูลการจองให้ครบถ้วน');
+    }
+
+    $evidence_image = 'no_image.jpg';
+    if (isset($_FILES['imgprofile']) && $_FILES['imgprofile']['error'] == 0) {
+        $fileName = basename($_FILES['imgprofile']['name']);
+        $targetFilePath = $targetDir . uniqid() . '_' . $fileName;
         $fileType = strtolower(pathinfo($targetFilePath, PATHINFO_EXTENSION));
-
-        // Validate file type and size (e.g., allow only images, max 5MB)
         $allowedTypes = ['jpg', 'jpeg', 'png', 'gif'];
-        $maxFileSize = 5 * 1024 * 1024; // 5MB in bytes
-        if (in_array($fileType, $allowedTypes) && $_FILES["imgprofile"]["size"] <= $maxFileSize) {
-            if (move_uploaded_file($_FILES["imgprofile"]["tmp_name"], $targetFilePath)) {
-                $evidence_image = basename($targetFilePath); // Store only the file name
+        $maxFileSize = 5 * 1024 * 1024;
+
+        if (in_array($fileType, $allowedTypes) && $_FILES['imgprofile']['size'] <= $maxFileSize) {
+            if (move_uploaded_file($_FILES['imgprofile']['tmp_name'], $targetFilePath)) {
+                $evidence_image = basename($targetFilePath);
             } else {
-                throw new Exception("Failed to upload image.");
+                throw new Exception('Failed to upload image.');
             }
         } else {
-            throw new Exception("Invalid file type or size. Only JPG, JPEG, PNG, GIF files under 5MB are allowed.");
+            throw new Exception('Invalid file type or size.');
         }
     }
 
-    // Calculate total duration and prices
     $total_duration = 0;
-    $total_price = 0;
-    $total_discount = 0;
-   $discount_name = null;
+    $total_price = 0.0;
+    $optionData = [];
+    $optionIds = [];
 
     foreach ($options as $index => $option_id) {
-        $stmt = $pdo->prepare("SELECT duration, price FROM service_option WHERE option_id = ?");
+        $option_id = (int) $option_id;
+        $stmt = $pdo->prepare('SELECT duration, price FROM service_option WHERE option_id = ?');
         $stmt->execute([$option_id]);
         $option = $stmt->fetch(PDO::FETCH_ASSOC);
         if (!$option) {
-            throw new Exception("Invalid option_id: $option_id");
+            throw new Exception('Invalid option_id: ' . $option_id);
         }
-        $total_duration += $option['duration'];
-        $total_price += $option['price'];
-
+        $duration = (int) $option['duration'];
+        $price = (float) $option['price'];
+        $total_duration += $duration;
+        $total_price += $price;
+        $optionData[$option_id] = [
+            'duration' => $duration,
+            'price' => $price
+        ];
+        $optionIds[] = $option_id;
     }
 
-    $end_time = date("H:i", strtotime("+$total_duration minutes", strtotime($start_time)));
+    $end_time = date('H:i', strtotime('+' . $total_duration . ' minutes', strtotime($start_time)));
+
+    $targetDateTime = combineDateAndTime($booking_date, $start_time);
+    $discountMap = [];
+    $total_discount = 0.0;
+    $discount_detail = '';
+
+    if ($targetDateTime && !empty($optionIds)) {
+        ensurePromotionSupport($conn);
+        $result = getApplicableOptionDiscounts($conn, $optionIds, $targetDateTime);
+        $discountMap = $result['by_option'];
+        $total_discount = (float) $result['total_discount'];
+        $discount_detail = summarizePromotionDiscountDetail($result['by_promotion']);
+    }
+
     $final_price = $total_price - $total_discount;
 
-    // Insert into booking with evidence
-    $stmt = $pdo->prepare("
-        INSERT INTO booking (customer_id, staff_id, booking_date, time_start, time_end, total_price, total_discount, final_price, status, discount_detail, evidence)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'confirmed', ?, ?)
-    ");
-    $stmt->execute([$customer_id, $staff_id, $booking_date, $start_time, $end_time, $total_price, $total_discount, $final_price, $discount_name, $evidence_image]);
+    $stmt = $pdo->prepare(
+        'INSERT INTO booking (customer_id, staff_id, booking_date, time_start, time_end, total_price, total_discount, final_price, status, discount_detail, evidence)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, "confirmed", ?, ?)'
+    );
+    $stmt->execute([
+        $customer_id,
+        $staff_id,
+        $booking_date,
+        $start_time,
+        $end_time,
+        $total_price,
+        $total_discount,
+        $final_price,
+        $discount_detail,
+        $evidence_image
+    ]);
     $booking_id = $pdo->lastInsertId();
 
-    // Insert into booking_seviceop
-    foreach ($options as $index => $option_id) {
-        $stmt = $pdo->prepare("SELECT price FROM service_option WHERE option_id = ?");
-        $stmt->execute([$option_id]);
-        $price = $stmt->fetchColumn();
-        if ($price === false) {
-            throw new Exception("Invalid option_id: $option_id");
-        }
-        $discount = 0;
+    $insertOptionStmt = $pdo->prepare('INSERT INTO booking_seviceop (booking_id, option_id, price_booking, discount_booking, net_price) VALUES (?, ?, ?, ?, ?)');
 
-        $net_price = $price - $discount;
-        $stmt = $pdo->prepare("INSERT INTO booking_seviceop (booking_id, option_id, price_booking, discount_booking, net_price) VALUES (?, ?, ?, ?, ?)");
-        $stmt->execute([$booking_id, $option_id, $price, $discount, $net_price]);
+    foreach ($optionIds as $option_id) {
+        $price = $optionData[$option_id]['price'];
+        $discountInfo = $discountMap[$option_id] ?? null;
+        $discountAmount = $discountInfo ? (float) $discountInfo['discount_amount'] : 0.0;
+        $netPrice = $price - $discountAmount;
+
+        $insertOptionStmt->execute([$booking_id, $option_id, $price, $discountAmount, $netPrice]);
     }
 
     $pdo->commit();
-    header("Location: table_booking.php"); // Redirect to table_booking.php
+    header('Location: table_booking.php');
     exit();
 } catch (Exception $e) {
     $pdo->rollBack();
-    echo "Error: " . $e->getMessage();
+    echo 'Error: ' . $e->getMessage();
 }
-?>

--- a/Admin/submit_booking.php
+++ b/Admin/submit_booking.php
@@ -64,14 +64,14 @@ try {
 
     $end_time = date('H:i', strtotime('+' . $total_duration . ' minutes', strtotime($start_time)));
 
-    $targetDateTime = combineDateAndTime($booking_date, $start_time);
+    $bookingMoment = date('Y-m-d H:i:s');
     $discountMap = [];
     $total_discount = 0.0;
     $discount_detail = '';
 
-    if ($targetDateTime && !empty($optionIds)) {
+    if (!empty($optionIds)) {
         ensurePromotionSupport($conn);
-        $result = getApplicableOptionDiscounts($conn, $optionIds, $targetDateTime);
+        $result = getApplicableOptionDiscounts($conn, $optionIds, $bookingMoment);
         $discountMap = $result['by_option'];
         $total_discount = (float) $result['total_discount'];
         $discount_detail = summarizePromotionDiscountDetail($result['by_promotion']);

--- a/Admin/table_promotion.php
+++ b/Admin/table_promotion.php
@@ -116,8 +116,6 @@ $result = $conn->query($sql);
                               <a href="promotion_detail.php?id=<?= $promotionId ?>" class="btn btn-outline-primary btn-sm">รายละเอียด</a>
                               <?php if ($status !== 'ended'): ?>
                                 <a href="promotion_update_form.php?id=<?= $promotionId ?>" class="btn btn-outline-secondary btn-sm">แก้ไข</a>
-                              <?php else: ?>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" disabled>แก้ไข</button>
                               <?php endif; ?>
 
                               <?php if ($status === 'upcoming'): ?>
@@ -131,7 +129,7 @@ $result = $conn->query($sql);
                                   <button type="submit" class="btn btn-outline-warning btn-sm">สิ้นสุดทันที</button>
                                 </form>
                               <?php else: ?>
-                                <span class="text-muted">-</span>
+
                               <?php endif; ?>
                             </div>
                           </td>

--- a/Admin/table_promotion.php
+++ b/Admin/table_promotion.php
@@ -1,20 +1,41 @@
 <?php
 session_start();
+require_once 'connect_db.php';
+require_once 'promotion_utils.php';
+
+ensurePromotionSupport($conn);
+
+$message = isset($_GET['message']) ? trim($_GET['message']) : '';
+$error = isset($_GET['error']) ? trim($_GET['error']) : '';
+
+$columns = getPromotionColumns($conn);
+$maxPercentByPromotion = [];
+$percentQuery = $conn->query("SELECT promotion_id, MAX(discount_percent) AS max_percent FROM promotion_service_option GROUP BY promotion_id");
+if ($percentQuery) {
+    while ($row = $percentQuery->fetch_assoc()) {
+        $maxPercentByPromotion[(int) $row['promotion_id']] = (float) $row['max_percent'];
+    }
+    $percentQuery->free();
+}
+
+$sql = "SELECT p.*, COUNT(ps.service_id) AS service_count
+        FROM promotion p
+        LEFT JOIN promotion_service ps ON p.promotion_id = ps.promotion_id
+        GROUP BY p.promotion_id
+        ORDER BY p.pm_start_date DESC";
+$result = $conn->query($sql);
 ?>
 <!DOCTYPE html>
 <html lang="en">
 
 <body>
-  <?php include("header.php"); ?>
-  <?php include("slidebar.php"); ?>
+  <?php include 'header.php'; ?>
+  <?php include 'slidebar.php'; ?>
 
   <main id="main" class="main">
 
     <div class="pagetitle">
-      <h1>Promotion Table</h1>
-      <nav>
-        <ol class="breadcrumb"></ol>
-      </nav>
+      <h1>จัดการโปรโมชั่น</h1>
     </div>
 
     <section class="section">
@@ -22,58 +43,108 @@ session_start();
         <div class="col-lg-12">
 
           <div class="card">
-            <div class="card-body">
+            <div class="card-body pt-4">
 
-              <div class="text-end mb-2">
-                <a href="form_promotion.php" class="btn btn-success mb-2">+ Add Promotion</a>
+              <div class="text-end mb-3">
+                <a href="form_promotion.php" class="btn btn-success"><i class="bi bi-plus"></i> เพิ่มโปรโมชั่น</a>
               </div>
 
-              <?php 
-              require_once("connect_db.php");
-              $sql = "SELECT * FROM promotion ORDER BY pm_created_at DESC";
-              $result = mysqli_query($conn, $sql);
-              ?>
+              <?php if (!empty($message)): ?>
+                <div class="alert alert-success alert-dismissible fade show" role="alert">
+                  <?= htmlspecialchars($message) ?>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+              <?php endif; ?>
 
-              <table class="table table-bordered table-striped">
-                <thead>
-                  <tr>
-                    <th>No.</th>
-                    <th>Promotion Name</th>
-                    <th>Discount (%)</th>
-                    <th>Start Date</th>
-                    <th>End Date</th>
-                    <th>Apply to All</th>
-                    <th>Status</th>
-                    <th>Detail</th>
-                    <th>Edit</th>
-                    <!-- <th>Delete</th> -->
-                  </tr>
-                </thead>
-                <tbody>
-                  <?php 
-                  $i = 1;
-                  while ($row = mysqli_fetch_assoc($result)) { ?>
+              <?php if (!empty($error)): ?>
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                  <?= htmlspecialchars($error) ?>
+                  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+              <?php endif; ?>
+
+              <div class="table-responsive">
+                <table class="table table-bordered table-hover align-middle">
+                  <thead class="table-light">
                     <tr>
-                      <td><?= $i++ ?></td>
-                      <td><?= htmlspecialchars($row['pm_name']) ?></td>
-                      <td><?= htmlspecialchars($row['discount']) ?></td>
-                      <td><?= htmlspecialchars($row['pm_start_date']) ?></td>
-                      <td><?= htmlspecialchars($row['pm_end_date']) ?></td>
-                      <td><?= $row['apply_to_all'] ? 'Yes' : 'No' ?></td>
-                      <td><?= $row['active'] ? 'Active' : 'Inactive' ?></td>
-                      <td>
-                        <a class="btn btn-outline-primary btn-sm" href="promotion_detail.php?id=<?= $row['promotion_id'] ?>">Detail</a>
-                      </td>
-                      <td>
-                        <a class="btn btn-outline-primary btn-sm" href="promotion_update_form.php?id=<?= $row['promotion_id'] ?>">Edit</a>
-                      </td>
-                      <!-- <td>
-                        <a class="btn btn-outline-danger btn-sm" href="promotion_delete.php?id=<?= $row['promotion_id'] ?>" onclick="return confirm('Are you sure you want to permanently delete this promotion?');">Delete</a>
-                      </td> -->
+                      <th scope="col">#</th>
+                      <th scope="col">ชื่อโปรโมชั่น</th>
+                      <th scope="col">วัน-เวลาเริ่มต้น</th>
+                      <th scope="col">วัน-เวลาสิ้นสุด</th>
+                      <th scope="col">สถานะ</th>
+                      <th scope="col">บริการที่เข้าร่วม</th>
+                      <th scope="col">ส่วนลดสูงสุด (%)</th>
+                      <th scope="col" class="text-center">การจัดการ</th>
                     </tr>
-                  <?php } ?>
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    <?php if ($result && $result->num_rows > 0): ?>
+                      <?php $i = 1; ?>
+                      <?php while ($row = $result->fetch_assoc()): ?>
+                        <?php
+                          $promotionId = (int) $row['promotion_id'];
+                          $status = promotionStatus($row['pm_start_date'], $row['pm_end_date']);
+                          $statusLabel = promotionStatusLabel($status);
+                          $serviceCount = (int) $row['service_count'];
+                          $maxPercent = $maxPercentByPromotion[$promotionId] ?? null;
+                          if ($maxPercent === null) {
+                              if (in_array('percent', $columns, true) && isset($row['percent'])) {
+                                  $maxPercent = (float) $row['percent'];
+                              } elseif (in_array('discount', $columns, true) && isset($row['discount'])) {
+                                  $maxPercent = (float) $row['discount'];
+                              } else {
+                                  $maxPercent = 0.0;
+                              }
+                          }
+                        ?>
+                        <tr>
+                          <td><?= $i++ ?></td>
+                          <td><?= htmlspecialchars($row['pm_name'] ?? '') ?></td>
+                          <td><?= htmlspecialchars(formatDateTimeDisplay($row['pm_start_date'] ?? '')) ?></td>
+                          <td><?= htmlspecialchars(formatDateTimeDisplay($row['pm_end_date'] ?? '')) ?></td>
+                          <td>
+                            <span class="badge
+                              <?php if ($status === 'running'): ?> bg-success<?php elseif ($status === 'upcoming'): ?> bg-warning text-dark<?php elseif ($status === 'ended'): ?> bg-secondary<?php else: ?> bg-light text-dark<?php endif; ?>
+                            ">
+                              <?= htmlspecialchars($statusLabel) ?>
+                            </span>
+                          </td>
+                          <td><?= $serviceCount ?></td>
+                          <td><?= number_format((float) $maxPercent, 2) ?></td>
+                          <td class="text-center">
+                            <div class="d-flex justify-content-center flex-wrap gap-2">
+                              <a href="promotion_detail.php?id=<?= $promotionId ?>" class="btn btn-outline-primary btn-sm">รายละเอียด</a>
+                              <?php if ($status !== 'ended'): ?>
+                                <a href="promotion_update_form.php?id=<?= $promotionId ?>" class="btn btn-outline-secondary btn-sm">แก้ไข</a>
+                              <?php else: ?>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" disabled>แก้ไข</button>
+                              <?php endif; ?>
+
+                              <?php if ($status === 'upcoming'): ?>
+                                <form action="promotion_delete.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการลบโปรโมชั่นนี้หรือไม่?');">
+                                  <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
+                                  <button type="submit" class="btn btn-outline-danger btn-sm">ลบ</button>
+                                </form>
+                              <?php elseif ($status === 'running'): ?>
+                                <form action="promotion_end.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการสิ้นสุดโปรโมชั่นนี้ทันทีหรือไม่?');">
+                                  <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
+                                  <button type="submit" class="btn btn-outline-warning btn-sm">สิ้นสุดทันที</button>
+                                </form>
+                              <?php else: ?>
+                                <span class="text-muted">-</span>
+                              <?php endif; ?>
+                            </div>
+                          </td>
+                        </tr>
+                      <?php endwhile; ?>
+                    <?php else: ?>
+                      <tr>
+                        <td colspan="8" class="text-center text-muted">ยังไม่มีข้อมูลโปรโมชั่น</td>
+                      </tr>
+                    <?php endif; ?>
+                  </tbody>
+                </table>
+              </div>
 
             </div>
           </div>
@@ -84,7 +155,7 @@ session_start();
 
   </main>
 
-  <?php include("footer.php"); ?>
+  <?php include 'footer.php'; ?>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Overhauled promotion creation, editing, and detail pages to support selecting services, toggling individual options, and managing promotion lifecycle actions. 【F:Admin/form_promotion.php†L1-L112】【F:Admin/promotion_update_form.php†L1-L141】【F:Admin/assets/js/promotion-form.js†L1-L263】【F:Admin/promotion_delete.php†L1-L56】【F:Admin/promotion_end.php†L1-L46】【F:Admin/promotion_utils.php†L1-L566】
- Added backend endpoints and storage logic for promotion services and option discounts, including transactional inserts/updates and status-aware table rendering. 【F:Admin/insert_promotion.php†L1-L120】【F:Admin/promotion_update.php†L1-L160】【F:Admin/table_promotion.php†L1-L139】【F:Admin/get_available_promotion_services.php†L1-L20】【F:Admin/get_applicable_promotions.php†L1-L31】【F:Admin/promotion_detail.php†L1-L128】
- Integrated promotion discounts into booking flows with automatic calculations and enriched booking summaries. 【F:Admin/booking.php†L1-L243】【F:Admin/submit_booking.php†L1-L120】【F:Admin/booking_detail.php†L1-L238】【F:Admin/check_promotion.php†L1-L28】【F:Admin/get_promotions.php†L1-L19】

## Testing
- php -l on updated PHP sources. 【748b73†L1-L8】【e13725†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68d249590ec0832d95b4524f3332ee19