### PR TITLE
Refactor booking status handling for numeric codes

### DIFF
--- a/Admin/api/available_staff.php
+++ b/Admin/api/available_staff.php
@@ -1,6 +1,7 @@
 <?php
 header('Content-Type: application/json');
 include("../connect_db.php");
+$cancelledStatus = BOOKING_STATUS_CANCELLED;
 
 $date = $_GET['date'] ?? '';
 $start_time = $_GET['time'] ?? '';
@@ -34,7 +35,7 @@ try {
         $conflict_query = "
             SELECT 1 FROM booking
             WHERE staff_ID = $staff_ID
-              AND booking_status != 'cancelled'
+              AND booking_status != {$cancelledStatus}
               AND time_start < '$end_str'
               AND ADDTIME(time_start, time_total) > '$start_str'
             LIMIT 1

--- a/Admin/booking_delete.php
+++ b/Admin/booking_delete.php
@@ -1,18 +1,21 @@
 <?php
 require_once "connect_db.php"; // เชื่อมต่อฐานข้อมูล
 
+$booking_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-    $booking_id = $_GET['id'];
+if ($booking_id <= 0) {
+  echo "ไม่พบข้อมูลการจอง";
+  exit;
+}
 
-    $sql = "UPDATE booking SET 
-            status = 'cancle'
-        WHERE booking_id = $booking_id";
+$cancelStatus = BOOKING_STATUS_CANCELLED;
+$stmt = $conn->prepare("UPDATE booking SET status = ? WHERE booking_id = ?");
+$stmt->bind_param("ii", $cancelStatus, $booking_id);
 
-    
-if (mysqli_query($conn, $sql)) {
+if ($stmt->execute()) {
   header("Location: table_booking.php"); // กลับไปหน้ารายชื่อสมาชิก
   exit;
 } else {
-  echo "เกิดข้อผิดพลาด: " . mysqli_error($conn);
+  echo "เกิดข้อผิดพลาด: " . $conn->error;
 }
 ?>

--- a/Admin/booking_detail.php
+++ b/Admin/booking_detail.php
@@ -86,31 +86,28 @@ $startStr = htmlspecialchars(substr($booking['time_start'], 0, 5));
 $endStr   = htmlspecialchars(substr($booking['time_end'],   0, 5));
 
 /* สถานะ & badge */
-$status = trim((string)$booking['status']);
-$badgeClass = 'bg-secondary';
-if ($status === 'confirmed') $badgeClass = 'bg-success';
-elseif ($status === 'pending') $badgeClass = 'bg-warning text-dark';
-elseif ($status === 'complate' || $status === 'completed') $badgeClass = 'bg-primary';
-elseif ($status === 'cancelled' || $status === 'rejected') $badgeClass = 'bg-danger';
+$statusCode  = booking_status_code($booking['status']);
+$statusLabel = booking_status_label($statusCode);
+$badgeClass  = booking_status_badge_class($statusCode);
 
 /* ปุ่มอัปเดตสถานะ (จะแสดงในแถว Status ของตารางเท่านั้น) */
 $statusActionBtn = '';
-if ($status === 'pending') {
+if ($statusCode === BOOKING_STATUS_PENDING) {
   $statusActionBtn = '
     <form action="update_booking_status.php" method="POST" class="d-inline"
           onsubmit="return confirm(\'ยืนยันเปลี่ยนสถานะเป็น Confirmed ?\');">
       <input type="hidden" name="booking_id" value="'.(int)$booking_id.'">
-      <input type="hidden" name="new_status" value="confirmed">
+      <input type="hidden" name="new_status" value="'.BOOKING_STATUS_CONFIRMED.'">
       <button type="submit" class="btn btn-success btn-sm">Mark as Confirmed</button>
     </form>
   ';
-} elseif ($status === 'confirmed') {
+} elseif ($statusCode === BOOKING_STATUS_CONFIRMED) {
   $statusActionBtn = '
     <form action="update_booking_status.php" method="POST" class="d-inline"
-          onsubmit="return confirm(\'ยืนยันเปลี่ยนสถานะเป็น Complate ?\');">
+          onsubmit="return confirm(\'ยืนยันเปลี่ยนสถานะเป็น Completed ?\');">
       <input type="hidden" name="booking_id" value="'.(int)$booking_id.'">
-      <input type="hidden" name="new_status" value="complate">
-      <button type="submit" class="btn btn-primary btn-sm">Mark as Complate</button>
+      <input type="hidden" name="new_status" value="'.BOOKING_STATUS_COMPLATE.'">
+      <button type="submit" class="btn btn-primary btn-sm">Mark as Completed</button>
     </form>
   ';
 }
@@ -154,7 +151,7 @@ if ($status === 'pending') {
       <td>
         <div class="d-flex align-items-center gap-2 flex-wrap">
           <span class="badge badge-status <?= $badgeClass ?>">
-            <?= htmlspecialchars($status ?: '—') ?>
+            <?= htmlspecialchars($statusLabel ?: '—') ?>
           </span>
           <?php if (!empty($statusActionBtn)): ?>
             <div class="ms-1"><?= $statusActionBtn ?></div>

--- a/Admin/connect_db.php
+++ b/Admin/connect_db.php
@@ -4,6 +4,8 @@
 $conn = new mysqli("127.0.0.1", "root","","first9");
 if ($conn->connect_error) {
     die("Connection failed: " . $conn->connect_error);
-} 
+}
+
+require_once __DIR__ . '/../booking_status.php';
 
 ?>

--- a/Admin/customer_bookings.php
+++ b/Admin/customer_bookings.php
@@ -1,5 +1,8 @@
 <?php
 require_once("connect_db.php");
+$confirmedStatus = BOOKING_STATUS_CONFIRMED;
+$pendingStatus   = BOOKING_STATUS_PENDING;
+$cancelledStatus = BOOKING_STATUS_CANCELLED;
 
 if (!isset($_GET['id'])) {
     echo "ไม่พบ Customer ID";
@@ -61,8 +64,8 @@ $stats_sql = "SELECT
     COUNT(*) as total_bookings,
     COALESCE(SUM(final_price), 0) as total_spent,
     COALESCE(AVG(final_price), 0) as avg_booking_value,
-    COUNT(CASE WHEN status = 'confirmed' THEN 1 END) as confirmed_bookings,
-    COUNT(CASE WHEN status = 'pending' THEN 1 END) as pending_bookings
+    COUNT(CASE WHEN status = {$confirmedStatus} THEN 1 END) as confirmed_bookings,
+    COUNT(CASE WHEN status = {$pendingStatus} THEN 1 END) as pending_bookings
 FROM booking 
 WHERE customer_id = ?";
 $stmt_stats = $conn->prepare($stats_sql);
@@ -239,13 +242,12 @@ $stats = $stats_result->fetch_assoc();
                         <td class="text-success fw-bold">€<?php echo number_format($booking['final_price'], 2); ?></td>
                         <td><?php echo htmlspecialchars($booking['discount_detail'] ?? 'N/A'); ?></td>
                         <td>
-                          <?php if ($booking['status'] === 'confirmed'): ?>
-                            <span class="badge bg-success">Confirmed</span>
-                          <?php elseif ($booking['status'] === 'pending'): ?>
-                            <span class="badge bg-warning">Pending</span>
-                          <?php else: ?>
-                            <span class="badge bg-secondary"><?php echo htmlspecialchars($booking['status'] ?? 'N/A'); ?></span>
-                          <?php endif; ?>
+                          <?php
+                            $statusCode = booking_status_code($booking['status']);
+                            $badgeClass = booking_status_badge_class($statusCode);
+                            $statusText = booking_status_label($statusCode);
+                          ?>
+                          <span class="badge <?php echo $badgeClass; ?>"><?php echo htmlspecialchars($statusText); ?></span>
                         </td>
                         <td>
                           <?php if (!empty($booking['evidence'])): ?>

--- a/Admin/index.php
+++ b/Admin/index.php
@@ -20,6 +20,8 @@ try {
     die("Connection failed: " . $e->getMessage());
 }
 
+require_once __DIR__ . '/../booking_status.php';
+
 // Get time period from URL parameter
 $period = $_GET['period'] ?? 'today';
 
@@ -73,10 +75,16 @@ function getKPIData($pdo, $dateRange) {
 
     
     // Cancellation rate (assuming we can identify cancelled bookings by status)
-    $stmt = $pdo->prepare("SELECT 
-        (SELECT COUNT(*) FROM booking WHERE booking_date BETWEEN ? AND ? AND status = 'cancelled') as cancelled,
+    $stmt = $pdo->prepare("SELECT
+        (SELECT COUNT(*) FROM booking WHERE booking_date BETWEEN ? AND ? AND status = ?) as cancelled,
         (SELECT COUNT(*) FROM booking WHERE booking_date BETWEEN ? AND ?) as total");
-    $stmt->execute([$dateRange['start'], $dateRange['end'], $dateRange['start'], $dateRange['end']]);
+    $stmt->execute([
+        $dateRange['start'],
+        $dateRange['end'],
+        BOOKING_STATUS_CANCELLED,
+        $dateRange['start'],
+        $dateRange['end']
+    ]);
     $cancelData = $stmt->fetch();
     $data['cancellation_rate'] = $cancelData['total'] > 0 ? round(($cancelData['cancelled'] / $cancelData['total']) * 100, 1) : 0;
     
@@ -411,20 +419,17 @@ for ($i = 6; $i >= 0; $i--) {
                                                 <td class="fw-bold">฿<?= number_format($booking['final_price'], 2) ?></td>
                                                 <td>
                                                     <?php
-                                                    $statusClass = match($booking['status']) {
-                                                        'confirmed' => 'success',
-                                                        'pending' => 'warning',
-                                                        'cancelled' => 'danger',
-                                                        default => 'secondary'
-                                                    };
-                                                    $statusText = match($booking['status']) {
-                                                        'confirmed' => 'ยืนยันแล้ว',
-                                                        'pending' => 'รอยืนยัน',
-                                                        'cancelled' => 'ยกเลิก',
-                                                        default => $booking['status']
-                                                    };
+                                                    $statusCode = booking_status_code($booking['status']);
+                                                    $statusTexts = [
+                                                        BOOKING_STATUS_CONFIRMED => 'ยืนยันแล้ว',
+                                                        BOOKING_STATUS_PENDING => 'รอยืนยัน',
+                                                        BOOKING_STATUS_CANCELLED => 'ยกเลิก',
+                                                        BOOKING_STATUS_COMPLATE => 'เสร็จสิ้น'
+                                                    ];
+                                                    $statusClass = booking_status_badge_class($statusCode);
+                                                    $statusText = $statusTexts[$statusCode] ?? booking_status_label($statusCode);
                                                     ?>
-                                                    <span class="badge bg-<?= $statusClass ?>"><?= $statusText ?></span>
+                                                    <span class="badge <?= $statusClass ?>"><?= htmlspecialchars($statusText) ?></span>
                                                 </td>
                                             </tr>
                                             <?php endforeach; ?>
@@ -523,11 +528,16 @@ for ($i = 6; $i >= 0; $i--) {
                                 </div>
                                 <?php
                                 // Get payment status data
-                                $stmt = $pdo->prepare("SELECT 
-                                    SUM(CASE WHEN status = 'confirmed' THEN final_price ELSE 0 END) as paid,
-                                    SUM(CASE WHEN status = 'pending' THEN final_price ELSE 0 END) as pending_payment
+                                $stmt = $pdo->prepare("SELECT
+                                    SUM(CASE WHEN status = ? THEN final_price ELSE 0 END) as paid,
+                                    SUM(CASE WHEN status = ? THEN final_price ELSE 0 END) as pending_payment
                                     FROM booking WHERE booking_date BETWEEN ? AND ?");
-                                $stmt->execute([$dateRange['start'], $dateRange['end']]);
+                                $stmt->execute([
+                                    BOOKING_STATUS_CONFIRMED,
+                                    BOOKING_STATUS_PENDING,
+                                    $dateRange['start'],
+                                    $dateRange['end']
+                                ]);
                                 $paymentData = $stmt->fetch();
                                 ?>
                                 <div class="mb-3 pb-3 border-bottom">

--- a/Admin/insert_booking.php
+++ b/Admin/insert_booking.php
@@ -107,8 +107,9 @@ try {
 
   $conn->begin_transaction();
   try {
-    $stmt = $conn->prepare("INSERT INTO booking (customer_id, staff_id, start_time, end_time, total_price, status) VALUES (?, ?, ?, ?, ?, 'pending')");
-    $stmt->bind_param("iissd", $customer_id, $staff_id, $start_datetime_str, $end_datetime_str, $price);
+    $stmt = $conn->prepare("INSERT INTO booking (customer_id, staff_id, start_time, end_time, total_price, status) VALUES (?, ?, ?, ?, ?, ?)");
+    $pendingStatus = BOOKING_STATUS_PENDING;
+    $stmt->bind_param("iissdi", $customer_id, $staff_id, $start_datetime_str, $end_datetime_str, $price, $pendingStatus);
     $stmt->execute();
     $booking_id = $stmt->insert_id;
     $stmt->close();

--- a/Admin/report_booking.php
+++ b/Admin/report_booking.php
@@ -24,9 +24,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
 
   // KPI cards (GLOBAL; not affected by chart filters)
   $k_total = (int)$conn->query("SELECT COUNT(*) c FROM booking")->fetch_assoc()['c'];
-  $k_conf  = (int)$conn->query("SELECT COUNT(*) c FROM booking WHERE status='confirmed'")->fetch_assoc()['c'];
-  $k_pend  = (int)$conn->query("SELECT COUNT(*) c FROM booking WHERE status='pending'")->fetch_assoc()['c'];
-  $k_canc  = (int)$conn->query("SELECT COUNT(*) c FROM booking WHERE status='cancelled'")->fetch_assoc()['c'];
+  $k_conf  = (int)$conn->query(sprintf("SELECT COUNT(*) c FROM booking WHERE status=%d", BOOKING_STATUS_CONFIRMED))->fetch_assoc()['c'];
+  $k_pend  = (int)$conn->query(sprintf("SELECT COUNT(*) c FROM booking WHERE status=%d", BOOKING_STATUS_PENDING))->fetch_assoc()['c'];
+  $k_canc  = (int)$conn->query(sprintf("SELECT COUNT(*) c FROM booking WHERE status=%d", BOOKING_STATUS_CANCELLED))->fetch_assoc()['c'];
 
   // Chart bucketing
   $labels=[]; $groupExpr=""; $dateFilter="1=1"; $axis='';
@@ -54,11 +54,15 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
   if($service>0) $w[]="EXISTS (SELECT 1 FROM booking_seviceop bs JOIN service_option so ON bs.option_id=so.option_id WHERE bs.booking_id=b.booking_id AND so.service_id=".$service.")";
   $where=implode(" AND ",$w);
 
+  $confStatus = BOOKING_STATUS_CONFIRMED;
+  $pendStatus = BOOKING_STATUS_PENDING;
+  $cancStatus = BOOKING_STATUS_CANCELLED;
+
   $sql="
     SELECT $groupExpr AS b,
-           SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS conf,
-           SUM(CASE WHEN b.status='pending'   THEN 1 ELSE 0 END) AS pend,
-           SUM(CASE WHEN b.status='cancelled' THEN 1 ELSE 0 END) AS canc,
+           SUM(CASE WHEN b.status=$confStatus THEN 1 ELSE 0 END) AS conf,
+           SUM(CASE WHEN b.status=$pendStatus THEN 1 ELSE 0 END) AS pend,
+           SUM(CASE WHEN b.status=$cancStatus THEN 1 ELSE 0 END) AS canc,
            COUNT(*) AS total
     FROM booking b
     WHERE $where
@@ -99,7 +103,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
 
 // ----------------------- TABLE: filters + sort + pagination -----------------------
 $search = trim($_GET['q'] ?? '');
-$status = $_GET['status'] ?? 'all';
+$statusParam = $_GET['status'] ?? 'all';
+$statusCode = $statusParam === 'all' ? null : booking_status_code($statusParam);
+$statusValue = $statusCode === null ? 'all' : (string)$statusCode;
 $staffF = isset($_GET['staff']) ? (int)$_GET['staff'] : 0;
 $serviceF = isset($_GET['service']) ? (int)$_GET['service'] : 0;
 $startDate = $_GET['start_date'] ?? '';
@@ -122,8 +128,8 @@ if($search!==''){
   $where[]="(c.customer_name LIKE ? OR c.gmail LIKE ? OR s.staff_name LIKE ?)";
   $kw="%$search%"; $params[]=$kw; $params[]=$kw; $params[]=$kw; $types.="sss";
 }
-if($status!=='all'){
-  $where[]="b.status=?"; $params[]=$status; $types.="s";
+if($statusCode !== null){
+  $where[]="b.status=?"; $params[]=$statusCode; $types.="i";
 }
 if($staffF>0){
   $where[]="b.staff_id=?"; $params[]=$staffF; $types.="i";
@@ -223,8 +229,14 @@ $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER B
           <div class="col-md-auto">
             <label class="form-label small-label">สถานะ</label>
             <select class="form-select" name="status">
-              <?php $opts=['all'=>'ทั้งหมด','confirmed'=>'confirmed','pending'=>'pending','cancelled'=>'cancelled']; foreach($opts as $k=>$v): ?>
-                <option value="<?=$k?>" <?= $status===$k?'selected':'' ?>><?=$v?></option>
+              <?php
+                $statusOptions = ['all' => 'ทั้งหมด'];
+                foreach (booking_status_options() as $code => $label) {
+                  $statusOptions[(string)$code] = $label;
+                }
+                foreach ($statusOptions as $key => $label):
+              ?>
+                <option value="<?=$key?>" <?= $statusValue === $key ? 'selected' : '' ?>><?=$label?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -308,8 +320,8 @@ $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER B
                   <td><?=esc($bk['staff_name']?:'N/A')?></td>
                   <td class="text-end text-success fw-bold">฿<?=number_format((float)$bk['final_price'],2)?></td>
                   <td>
-                    <?php $st=strtolower($bk['status']); $bclass= $st==='confirmed'?'success':($st==='pending'?'warning':'danger'); ?>
-                    <span class="badge bg-<?=$bclass?>"><?=esc(ucfirst($st) ?: 'N/A')?></span>
+                    <?php $stCode = booking_status_code($bk['status']); $badgeClass = booking_status_badge_class($stCode); $label = booking_status_label($stCode); ?>
+                    <span class="badge <?=$badgeClass?>"><?=esc($label ?: 'N/A')?></span>
                   </td>
                   <td>
                     <div class="btn-group">

--- a/Admin/report_income.php
+++ b/Admin/report_income.php
@@ -5,6 +5,9 @@
 // Optional service linkage: booking_seviceop(option_id, booking_id) -> service_option(option_id, service_id) -> service(service_id, service_name)
 
 require_once("connect_db.php");
+$confirmedStatus = BOOKING_STATUS_CONFIRMED;
+$pendingStatus   = BOOKING_STATUS_PENDING;
+$cancelledStatus = BOOKING_STATUS_CANCELLED;
 function esc($s){return htmlspecialchars($s??'',ENT_QUOTES,'UTF-8');}
 
 // ----------------------- Year range meta for chart pickers -----------------------
@@ -27,11 +30,11 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
   $service= isset($_GET['service'])? (int)$_GET['service'] : 0;
 
   // ---------- KPI (GLOBAL; confirmed only) ----------
-  $k_net_total = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status='confirmed'")->fetch_assoc()['s'];
-  $k_gross_total = (float)$conn->query("SELECT COALESCE(SUM(total_price),0) s FROM booking WHERE status='confirmed'")->fetch_assoc()['s'];
-  $k_disc_total = (float)$conn->query("SELECT COALESCE(SUM(total_discount),0) s FROM booking WHERE status='confirmed'")->fetch_assoc()['s'];
+  $k_net_total = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
+  $k_gross_total = (float)$conn->query("SELECT COALESCE(SUM(total_price),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
+  $k_disc_total = (float)$conn->query("SELECT COALESCE(SUM(total_discount),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
   $ym = date('Y-m');
-  $k_net_mtd = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status='confirmed' AND DATE_FORMAT(booking_date,'%Y-%m')='$ym'")->fetch_assoc()['s'];
+  $k_net_mtd = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status={$confirmedStatus} AND DATE_FORMAT(booking_date,'%Y-%m')='$ym'")->fetch_assoc()['s'];
 
   // ---------- Chart bucketing ----------
   $labels=[]; $groupExpr=""; $dateFilter="1=1"; $axis='';
@@ -56,7 +59,7 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
   // confirmed revenue only; optional staff/service filters
   $w=[];
   $w[]=$dateFilter;
-  $w[]="b.status='confirmed'";
+  $w[]="b.status={$confirmedStatus}";
   if($staff>0)   $w[]="b.staff_id=".$staff;
   if($service>0) $w[]="EXISTS (SELECT 1 FROM booking_seviceop bs JOIN service_option so ON bs.option_id=so.option_id WHERE bs.booking_id=b.booking_id AND so.service_id=".$service.")";
   $where=implode(" AND ",$w);
@@ -108,7 +111,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
 
 // ======================= TABLE: filters + sort + pagination =======================
 $search = trim($_GET['q'] ?? '');
-$status = $_GET['status'] ?? 'confirmed'; // default confirmed for income
+$statusParam = $_GET['status'] ?? (string)$confirmedStatus; // default confirmed for income
+$statusCode = $statusParam === 'all' ? null : booking_status_code($statusParam);
+$statusValue = $statusCode === null ? 'all' : (string)$statusCode;
 $staffF = isset($_GET['staff']) ? (int)$_GET['staff'] : 0;
 $serviceF = isset($_GET['service']) ? (int)$_GET['service'] : 0;
 $startDate = $_GET['start_date'] ?? '';
@@ -133,8 +138,8 @@ if($search!==''){
   $where[]="(c.customer_name LIKE ? OR c.gmail LIKE ? OR s.staff_name LIKE ?)";
   $kw="%$search%"; $params[]=$kw; $params[]=$kw; $params[]=$kw; $types.="sss";
 }
-if($status!=='all'){
-  $where[]="b.status=?"; $params[]=$status; $types.="s";
+if($statusCode !== null){
+  $where[]="b.status=?"; $params[]=$statusCode; $types.="i";
 }
 if($staffF>0){
   $where[]="b.staff_id=?"; $params[]=$staffF; $types.="i";
@@ -247,8 +252,14 @@ $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER B
           <div class="col-md-auto">
             <label class="form-label small-label">สถานะ</label>
             <select class="form-select" name="status">
-              <?php $opts=['confirmed'=>'confirmed','all'=>'ทั้งหมด','pending'=>'pending','cancelled'=>'cancelled']; foreach($opts as $k=>$v): ?>
-                <option value="<?=$k?>" <?= $status===$k?'selected':'' ?>><?=$v?></option>
+              <?php
+                $statusOptions = ['all' => 'ทั้งหมด'];
+                foreach (booking_status_options() as $code => $label) {
+                  $statusOptions[(string)$code] = $label;
+                }
+                foreach ($statusOptions as $key => $label):
+              ?>
+                <option value="<?=$key?>" <?= $statusValue === $key ? 'selected' : '' ?>><?=$label?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -336,8 +347,8 @@ $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER B
                   <td class="text-end text-danger">-<?=number_format((float)$r['total_discount'],2)?></td>
                   <td class="text-end fw-bold text-success"><?=number_format((float)$r['final_price'],2)?></td>
                   <td>
-                    <?php $st=strtolower($r['status']); $bclass=$st==='confirmed'?'success':($st==='pending'?'warning':'secondary'); ?>
-                    <span class="badge bg-<?=$bclass?>"><?=esc(ucfirst($st))?></span>
+                    <?php $stCode = booking_status_code($r['status']); $badgeClass = booking_status_badge_class($stCode); $label = booking_status_label($stCode); ?>
+                    <span class="badge <?=$badgeClass?>"><?=esc($label)?></span>
                   </td>
                   <td>
                     <div class="btn-group">

--- a/Admin/report_service.php
+++ b/Admin/report_service.php
@@ -11,6 +11,7 @@
 //   customer(customer_id, ...), staff(staff_id, ...)
 
 require_once("connect_db.php");
+$confirmedStatus = BOOKING_STATUS_CONFIRMED;
 function esc($s){ return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); }
 
 // ----------------------- Year range meta for pickers -----------------------
@@ -42,7 +43,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'stats') {
       COUNT(*)                       AS tx,
       COUNT(DISTINCT customer_id)    AS customers
     FROM booking
-    WHERE status='confirmed'
+    WHERE status={$confirmedStatus}
   ")->fetch_assoc();
   $net_total = (float)$k['net'];
   $tx_total = (int)$k['tx'];
@@ -52,7 +53,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'stats') {
     FROM booking b
     JOIN booking_seviceop bs ON bs.booking_id=b.booking_id
     JOIN service_option so ON so.option_id=bs.option_id
-    WHERE b.status='confirmed'
+    WHERE b.status={$confirmedStatus}
   ")->fetch_assoc()['c'];
   // top service (by net, all time)
   $top = $conn->query("
@@ -61,7 +62,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'stats') {
     JOIN booking_seviceop bs ON bs.booking_id=b.booking_id
     JOIN service_option so ON so.option_id=bs.option_id
     JOIN service sv ON sv.service_id=so.service_id
-    WHERE b.status='confirmed'
+    WHERE b.status={$confirmedStatus}
     GROUP BY sv.service_id
     ORDER BY net DESC
     LIMIT 1
@@ -95,7 +96,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'stats') {
     $rangeEnd  =sprintf('%04d-12-31',$endY);
   }
 
-  $extra = ["b.status='confirmed'"];
+  $extra = ["b.status={$confirmedStatus}"];
   if ($staffId > 0)   $extra[] = "b.staff_id=".$staffId;
   $whereBase = "$dateCond AND ".implode(" AND ",$extra);
 
@@ -192,7 +193,7 @@ $sortMap=[
 $orderBy = $sortMap[$sort] ?? $sortMap['net'];
 
 // WHERE for aggregated query
-$where = ["b.status='confirmed'"]; $types=""; $params=[];
+$where = ["b.status={$confirmedStatus}"]; $types=""; $params=[];
 if ($q!==''){ $where[]="sv.service_name LIKE ?"; $kw="%$q%"; $params[]=$kw; $types.="s"; }
 if ($staffF>0){ $where[]="b.staff_id=?"; $params[]=$staffF; $types.="i"; }
 if ($startDate!==''){ $where[]="b.booking_date>=?"; $params[]=$startDate; $types.="s"; }
@@ -290,7 +291,7 @@ $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER B
           <div class="col-md-auto">
             <label class="form-label small-label">สถานะ</label>
             <select class="form-select" name="status" disabled>
-              <option value="confirmed" selected>confirmed (ยึดสำหรับรายได้)</option>
+              <option value="<?=BOOKING_STATUS_CONFIRMED?>" selected>Confirmed (ยึดสำหรับรายได้)</option>
             </select>
           </div>
           <div class="col-md-auto">

--- a/Admin/report_staff.php
+++ b/Admin/report_staff.php
@@ -13,6 +13,9 @@
 //   service(service_id, service_name)
 //   customer(customer_id, customer_name, gmail)
 require_once("connect_db.php");
+$pendingStatus   = BOOKING_STATUS_PENDING;
+$confirmedStatus = BOOKING_STATUS_CONFIRMED;
+$cancelledStatus = BOOKING_STATUS_CANCELLED;
 function esc($s){ return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); }
 
 // ---------------- Year meta for chart pickers ----------------
@@ -37,15 +40,15 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
 
   // ---------- KPI (GLOBAL; all time) ----------
   $total_staff = (int)$conn->query("SELECT COUNT(*) c FROM staff")->fetch_assoc()['c'];
-  $confirmed_rev = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status='confirmed'")->fetch_assoc()['s'];
-  $confirmed_tx  = (int)$conn->query("SELECT COUNT(*) c FROM booking WHERE status='confirmed'")->fetch_assoc()['c'];
+  $confirmed_rev = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
+  $confirmed_tx  = (int)$conn->query("SELECT COUNT(*) c FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['c'];
   $avg_rev_per_staff = $total_staff>0 ? $confirmed_rev / $total_staff : 0.0;
 
   // Top performer overall
   $tp = $conn->query("
     SELECT s.staff_name, COALESCE(SUM(b.final_price),0) net
     FROM staff s
-    LEFT JOIN booking b ON b.staff_id=s.staff_id AND b.status='confirmed'
+    LEFT JOIN booking b ON b.staff_id=s.staff_id AND b.status={$confirmedStatus}
     GROUP BY s.staff_id
     ORDER BY net DESC
     LIMIT 1
@@ -83,11 +86,11 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
   // ---------- Time series: bookings count per status + net revenue ----------
   $sql="
     SELECT $groupExpr AS bucket,
-           SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS confirmed,
-           SUM(CASE WHEN b.status='pending'   THEN 1 ELSE 0 END) AS pending,
-           SUM(CASE WHEN b.status='cancelled' THEN 1 ELSE 0 END) AS cancelled,
+           SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS confirmed,
+           SUM(CASE WHEN b.status={$pendingStatus}   THEN 1 ELSE 0 END) AS pending,
+           SUM(CASE WHEN b.status={$cancelledStatus} THEN 1 ELSE 0 END) AS cancelled,
            COUNT(*) AS total,
-           COALESCE(SUM(CASE WHEN b.status='confirmed' THEN b.final_price ELSE 0 END),0) AS net_rev
+           COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) AS net_rev
     FROM booking b
     WHERE $where
     GROUP BY bucket
@@ -117,8 +120,8 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
   if ($serviceId>0) $ws .= " AND EXISTS (SELECT 1 FROM booking_seviceop bs2 JOIN service_option so2 ON bs2.option_id=so2.option_id WHERE bs2.booking_id=b.booking_id AND so2.service_id=".$serviceId.")";
 
   $sqlTopNet="
-    SELECT s.staff_name, COALESCE(SUM(CASE WHEN b.status='confirmed' THEN b.final_price ELSE 0 END),0) AS net,
-           SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS tx_conf
+    SELECT s.staff_name, COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) AS net,
+           SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS tx_conf
     FROM staff s
     LEFT JOIN booking b ON b.staff_id=s.staff_id AND $ws
     GROUP BY s.staff_id
@@ -130,8 +133,8 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
 
   $sqlTopTx="
     SELECT s.staff_name,
-           SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS tx_conf,
-           COALESCE(SUM(CASE WHEN b.status='confirmed' THEN b.final_price ELSE 0 END),0) AS net
+           SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS tx_conf,
+           COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) AS net
     FROM staff s
     LEFT JOIN booking b ON b.staff_id=s.staff_id AND $ws
     GROUP BY s.staff_id
@@ -146,9 +149,9 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
   if ($staffId>0) $wm .= " AND b.staff_id=".$staffId;
   $mix = $conn->query("
     SELECT
-      SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS confirmed,
-      SUM(CASE WHEN b.status='pending'   THEN 1 ELSE 0 END) AS pending,
-      SUM(CASE WHEN b.status='cancelled' THEN 1 ELSE 0 END) AS cancelled
+      SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS confirmed,
+      SUM(CASE WHEN b.status={$pendingStatus}   THEN 1 ELSE 0 END) AS pending,
+      SUM(CASE WHEN b.status={$cancelledStatus} THEN 1 ELSE 0 END) AS cancelled
     FROM booking b
     WHERE $wm
   ")->fetch_assoc();
@@ -214,16 +217,16 @@ $sql="
   SELECT
     s.staff_id, s.staff_name,
     SUM(1)                                   AS tx_total,
-    SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END) AS tx_conf,
-    SUM(CASE WHEN b.status='pending'   THEN 1 ELSE 0 END) AS tx_pend,
-    SUM(CASE WHEN b.status='cancelled' THEN 1 ELSE 0 END) AS tx_canc,
-    COALESCE(SUM(CASE WHEN b.status='confirmed' THEN b.final_price ELSE 0 END),0) AS net_rev,
-    CASE WHEN SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END)=0
+    SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS tx_conf,
+    SUM(CASE WHEN b.status={$pendingStatus}   THEN 1 ELSE 0 END) AS tx_pend,
+    SUM(CASE WHEN b.status={$cancelledStatus} THEN 1 ELSE 0 END) AS tx_canc,
+    COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) AS net_rev,
+    CASE WHEN SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END)=0
          THEN 0
-         ELSE COALESCE(SUM(CASE WHEN b.status='confirmed' THEN b.final_price ELSE 0 END),0) /
-              SUM(CASE WHEN b.status='confirmed' THEN 1 ELSE 0 END)
+         ELSE COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) /
+              SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END)
     END AS aov,
-    COUNT(DISTINCT CASE WHEN b.status='confirmed' THEN b.customer_id END) AS custs,
+    COUNT(DISTINCT CASE WHEN b.status={$confirmedStatus} THEN b.customer_id END) AS custs,
     COALESCE(SUM(TIME_TO_SEC(TIMEDIFF(b.time_end, b.time_start)))/3600,0) AS hrs,
     AVG(TIME_TO_SEC(TIMEDIFF(b.time_end, b.time_start))/60) AS avgdur,
     MIN(b.booking_date) AS first_bk,

--- a/Admin/report_staff.php
+++ b/Admin/report_staff.php
@@ -15,6 +15,7 @@
 require_once("connect_db.php");
 $pendingStatus   = BOOKING_STATUS_PENDING;
 $confirmedStatus = BOOKING_STATUS_CONFIRMED;
+$completedStatus = BOOKING_STATUS_COMPLATE;
 $cancelledStatus = BOOKING_STATUS_CANCELLED;
 function esc($s){ return htmlspecialchars($s ?? '', ENT_QUOTES, 'UTF-8'); }
 
@@ -194,6 +195,7 @@ $sortMap=[
   'net'    => "net_rev $dir",
   'tx'     => "tx_total $dir",
   'conf'   => "tx_conf $dir",
+  'comp'   => "tx_comp $dir",
   'pend'   => "tx_pend $dir",
   'canc'   => "tx_canc $dir",
   'aov'    => "aov $dir",
@@ -218,6 +220,7 @@ $sql="
     s.staff_id, s.staff_name,
     SUM(1)                                   AS tx_total,
     SUM(CASE WHEN b.status={$confirmedStatus} THEN 1 ELSE 0 END) AS tx_conf,
+    SUM(CASE WHEN b.status={$completedStatus} THEN 1 ELSE 0 END) AS tx_comp,
     SUM(CASE WHEN b.status={$pendingStatus}   THEN 1 ELSE 0 END) AS tx_pend,
     SUM(CASE WHEN b.status={$cancelledStatus} THEN 1 ELSE 0 END) AS tx_canc,
     COALESCE(SUM(CASE WHEN b.status={$confirmedStatus} THEN b.final_price ELSE 0 END),0) AS net_rev,
@@ -252,6 +255,7 @@ $totalRows = count($rows);
 $summary = [
   'tx_total' => 0,
   'tx_conf'  => 0,
+  'tx_comp'  => 0,
   'tx_pend'  => 0,
   'tx_canc'  => 0,
   'net_rev'  => 0.0,
@@ -263,6 +267,7 @@ $summary = [
 foreach ($rows as $row) {
   $summary['tx_total'] += (int)($row['tx_total'] ?? 0);
   $summary['tx_conf']  += (int)($row['tx_conf'] ?? 0);
+  $summary['tx_comp']  += (int)($row['tx_comp'] ?? 0);
   $summary['tx_pend']  += (int)($row['tx_pend'] ?? 0);
   $summary['tx_canc']  += (int)($row['tx_canc'] ?? 0);
   $summary['net_rev']  += (float)($row['net_rev'] ?? 0);
@@ -340,6 +345,7 @@ $staffOps   = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staf
                 <option value="net"   <?= $sort==='net'?'selected':'' ?>>Net Revenue</option>
                 <option value="tx"    <?= $sort==='tx'?'selected':'' ?>>Bookings (ทั้งหมด)</option>
                 <option value="conf"  <?= $sort==='conf'?'selected':'' ?>>Confirmed</option>
+                <option value="comp"  <?= $sort==='comp'?'selected':'' ?>>Complate</option>
                 <option value="pend"  <?= $sort==='pend'?'selected':'' ?>>Pending</option>
                 <option value="canc"  <?= $sort==='canc'?'selected':'' ?>>Cancelled</option>
                 <option value="aov"   <?= $sort==='aov'?'selected':'' ?>>AOV</option>
@@ -371,6 +377,7 @@ $staffOps   = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staf
                 <th>Staff</th>
                 <th class="text-end">Bookings</th>
                 <th class="text-end">Confirmed</th>
+                <th class="text-end">Complate</th>
                 <th class="text-end">Pending</th>
                 <th class="text-end">Cancelled</th>
                 <th class="text-end">Net Revenue</th>
@@ -395,6 +402,7 @@ $staffOps   = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staf
                   <td><?=esc($r['staff_name']?:'N/A')?></td>
                   <td class="text-end"><?=number_format((int)$r['tx_total'])?></td>
                   <td class="text-end"><span class="badge bg-success"><?=number_format((int)$r['tx_conf'])?></span></td>
+                  <td class="text-end"><span class="badge bg-primary"><?=number_format((int)$r['tx_comp'])?></span></td>
                   <td class="text-end"><span class="badge bg-warning text-dark"><?=number_format((int)$r['tx_pend'])?></span></td>
                   <td class="text-end"><span class="badge bg-danger"><?=number_format((int)$r['tx_canc'])?></span></td>
                   <td class="text-end fw-bold text-success">฿<?=number_format((float)$r['net_rev'],2)?></td>
@@ -418,6 +426,7 @@ $staffOps   = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staf
                 <th>รวม</th>
                 <th class="text-end fw-bold"><?=number_format($summary['tx_total'])?></th>
                 <th class="text-end"><span class="badge bg-success"><?=number_format($summary['tx_conf'])?></span></th>
+                <th class="text-end"><span class="badge bg-primary"><?=number_format($summary['tx_comp'])?></span></th>
                 <th class="text-end"><span class="badge bg-warning text-dark"><?=number_format($summary['tx_pend'])?></span></th>
                 <th class="text-end"><span class="badge bg-secondary"><?=number_format($summary['tx_canc'])?></span></th>
                 <th class="text-end fw-bold text-success">฿<?=number_format($summary['net_rev'],2)?></th>

--- a/Admin/schedule.php
+++ b/Admin/schedule.php
@@ -152,9 +152,12 @@ while ($row = $schedule_result->fetch_assoc()) {
                         <td><?= htmlspecialchars($schedule['services']) ?></td>
                         <td>€<?= number_format($schedule['final_price'], 2) ?></td>
                         <td>
-                          <?= htmlspecialchars($schedule['status']) === 'confirmed' 
-                              ? '<span class="text-success">Confirmed</span>' 
-                              : '<span class="text-danger">' . htmlspecialchars($schedule['status']) . '</span>' ?>
+                          <?php
+                            $statusCode = booking_status_code($schedule['status']);
+                            $badgeClass = booking_status_badge_class($statusCode);
+                            $statusText = booking_status_label($statusCode);
+                          ?>
+                          <span class="badge <?php echo $badgeClass; ?>"><?php echo htmlspecialchars($statusText); ?></span>
                         </td>
                         <td>
                           <button class="btn btn-info btn-sm" 
@@ -166,7 +169,7 @@ while ($row = $schedule_result->fetch_assoc()) {
                                   data-customer="<?= htmlspecialchars($schedule['customer_name']) ?>"
                                   data-services="<?= htmlspecialchars($schedule['services']) ?>"
                                   data-price="€<?= number_format($schedule['final_price'], 2) ?>"
-                                  data-status="<?= htmlspecialchars($schedule['status']) ?>">View</button>
+                                  data-status="<?= htmlspecialchars(booking_status_label($schedule['status'])) ?>">View</button>
                         </td>
                       </tr>
                     <?php endforeach; ?>
@@ -253,7 +256,7 @@ while ($row = $schedule_result->fetch_assoc()) {
               customer: <?= json_encode($schedule['customer_name'] ?? 'Unknown Customer') ?>,
               services: <?= json_encode($schedule['services'] ?? 'No Services') ?>,
               price: <?= json_encode('€' . number_format($schedule['final_price'] ?? 0, 2)) ?>,
-              status: <?= json_encode($schedule['status'] ?? 'Unknown') ?>,
+              status: <?= json_encode(booking_status_label($schedule['status']) ?? 'Unknown') ?>,
               time: <?= json_encode(($schedule['time_start'] ?? '') . ' - ' . ($schedule['time_end'] ?? '')) ?>
             }
           }<?= $index < $total_schedules - 1 ? ',' : '' ?>

--- a/Admin/submit_booking.php
+++ b/Admin/submit_booking.php
@@ -81,7 +81,7 @@ try {
 
     $stmt = $pdo->prepare(
         'INSERT INTO booking (customer_id, staff_id, booking_date, time_start, time_end, total_price, total_discount, final_price, status, discount_detail, evidence)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, "confirmed", ?, ?)'
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     );
     $stmt->execute([
         $customer_id,
@@ -92,6 +92,7 @@ try {
         $total_price,
         $total_discount,
         $final_price,
+        BOOKING_STATUS_CONFIRMED,
         $discount_detail,
         $evidence_image
     ]);

--- a/Admin/update_booking_status.php
+++ b/Admin/update_booking_status.php
@@ -14,9 +14,9 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $booking_id = (int)($_POST['booking_id'] ?? 0);
-$new_status = trim($_POST['new_status'] ?? '');
+$new_status = booking_status_code($_POST['new_status'] ?? null);
 
-if (!$booking_id || $new_status === '') {
+if (!$booking_id || $new_status === null) {
   exit('ข้อมูลไม่ครบ');
 }
 
@@ -28,23 +28,23 @@ $row = $stmt->get_result()->fetch_assoc();
 $stmt->close();
 
 if (!$row) exit("ไม่พบการจอง");
-$current = trim((string)$row['status']);
+$current = booking_status_code($row['status']);
+if ($current === null) {
+  exit('ไม่สามารถระบุสถานะปัจจุบันได้');
+}
 
 // อนุญาตเฉพาะ transition: pending -> confirmed -> complate
 $allowed = false;
-if ($current === 'pending'   && $new_status === 'confirmed') $allowed = true;
-if ($current === 'confirmed' && $new_status === 'complate')  $allowed = true;
-
-// (ถ้าอนาคตจะเปลี่ยนมาใช้คำว่า completed ก็รองรับเพิ่ม)
-// if ($current === 'confirmed' && $new_status === 'completed') $allowed = true;
+if ($current === BOOKING_STATUS_PENDING   && $new_status === BOOKING_STATUS_CONFIRMED) $allowed = true;
+if ($current === BOOKING_STATUS_CONFIRMED && $new_status === BOOKING_STATUS_COMPLATE)  $allowed = true;
 
 if (!$allowed) {
-  exit("ไม่อนุญาตให้อัปเดตสถานะจาก '$current' เป็น '$new_status'");
+  exit("ไม่อนุญาตให้อัปเดตสถานะจาก '" . booking_status_label($current) . "' เป็น '" . booking_status_label($new_status) . "'");
 }
 
 // อัปเดต
 $upd = $conn->prepare("UPDATE booking SET status = ? WHERE booking_id = ?");
-$upd->bind_param("si", $new_status, $booking_id);
+$upd->bind_param("ii", $new_status, $booking_id);
 $upd->execute();
 $upd->close();
 

--- a/booking_status.php
+++ b/booking_status.php
@@ -1,0 +1,113 @@
+<?php
+// Shared helper for booking status codes and labels
+if (!defined('BOOKING_STATUS_PENDING')) {
+    define('BOOKING_STATUS_PENDING', 1);
+    define('BOOKING_STATUS_CONFIRMED', 2);
+    define('BOOKING_STATUS_COMPLATE', 3);
+    define('BOOKING_STATUS_CANCELLED', 4);
+}
+
+if (!function_exists('booking_status_code')) {
+    function booking_status_code($value)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (int)$value;
+        }
+        $normalized = strtolower(trim((string)$value));
+        switch ($normalized) {
+            case '1':
+            case 'pending':
+                return BOOKING_STATUS_PENDING;
+            case '2':
+            case 'confirmed':
+            case 'confirm':
+                return BOOKING_STATUS_CONFIRMED;
+            case '3':
+            case 'complate':
+            case 'completed':
+            case 'complete':
+                return BOOKING_STATUS_COMPLATE;
+            case '4':
+            case 'cancelled':
+            case 'canceled':
+            case 'cancel':
+            case 'cancle':
+            case 'rejected':
+                return BOOKING_STATUS_CANCELLED;
+            default:
+                return null;
+        }
+    }
+}
+
+if (!function_exists('booking_status_slug')) {
+    function booking_status_slug($value)
+    {
+        switch (booking_status_code($value)) {
+            case BOOKING_STATUS_PENDING:
+                return 'pending';
+            case BOOKING_STATUS_CONFIRMED:
+                return 'confirmed';
+            case BOOKING_STATUS_COMPLATE:
+                return 'complate';
+            case BOOKING_STATUS_CANCELLED:
+                return 'cancelled';
+            default:
+                return '';
+        }
+    }
+}
+
+if (!function_exists('booking_status_label')) {
+    function booking_status_label($value)
+    {
+        switch (booking_status_code($value)) {
+            case BOOKING_STATUS_PENDING:
+                return 'Pending';
+            case BOOKING_STATUS_CONFIRMED:
+                return 'Confirmed';
+            case BOOKING_STATUS_COMPLATE:
+                return 'Completed';
+            case BOOKING_STATUS_CANCELLED:
+                return 'Cancelled';
+            default:
+                return 'Unknown';
+        }
+    }
+}
+
+if (!function_exists('booking_status_badge_class')) {
+    function booking_status_badge_class($value)
+    {
+        switch (booking_status_code($value)) {
+            case BOOKING_STATUS_CONFIRMED:
+                return 'bg-success';
+            case BOOKING_STATUS_COMPLATE:
+                return 'bg-primary';
+            case BOOKING_STATUS_CANCELLED:
+                return 'bg-danger';
+            case BOOKING_STATUS_PENDING:
+                return 'bg-warning text-dark';
+            default:
+                return 'bg-secondary';
+        }
+    }
+}
+
+if (!function_exists('booking_status_options')) {
+    function booking_status_options()
+    {
+        return [
+            BOOKING_STATUS_PENDING   => 'Pending',
+            BOOKING_STATUS_CONFIRMED => 'Confirmed',
+            BOOKING_STATUS_COMPLATE  => 'Completed',
+            BOOKING_STATUS_CANCELLED => 'Cancelled',
+        ];
+    }
+}

--- a/new2/connect_db.php
+++ b/new2/connect_db.php
@@ -4,6 +4,8 @@
 $conn = new mysqli("127.0.0.1", "root","","first9");
 if ($conn->connect_error) {
     die("Connection failed: " . $conn->connect_error);
-} 
+}
+
+require_once __DIR__ . '/../booking_status.php';
 
 ?>

--- a/new2/index.php
+++ b/new2/index.php
@@ -1,5 +1,7 @@
 <?php
 require_once 'connect_db.php';
+$confirmedStatus = BOOKING_STATUS_CONFIRMED;
+$completedStatus = BOOKING_STATUS_COMPLATE;
 
 $hotServices = [];
 
@@ -16,7 +18,7 @@ if (isset($conn) && $conn instanceof mysqli) {
         JOIN booking_seviceop bs ON b.booking_id = bs.booking_id
         JOIN service_option so ON bs.option_id = so.option_id
         JOIN service sv ON so.service_id = sv.service_id
-        WHERE b.status IN ('confirmed', 'completed')
+        WHERE b.status IN ($confirmedStatus, $completedStatus)
         GROUP BY sv.service_id, sv.service_name, sv.description, sv.coverimg
         ORDER BY total_bookings DESC, sv.service_name ASC
         LIMIT 3

--- a/new2/profileuser.php
+++ b/new2/profileuser.php
@@ -58,18 +58,10 @@ $english_months = [
 }
 
 function getStatusBadge($status) {
-    switch ($status) {
-        case 'confirmed':
-            return '<span class="badge bg-success">Confirmed</span>';
-        case 'pending':
-            return '<span class="badge bg-warning">Pending</span>';
-        case 'completed':
-            return '<span class="badge bg-primary">Completed</span>';
-        case 'cancelled':
-            return '<span class="badge bg-danger">Cancelled</span>';
-        default:
-            return '<span class="badge bg-secondary">' . ucfirst($status) . '</span>';
-    }
+    $code  = booking_status_code($status);
+    $class = booking_status_badge_class($code);
+    $label = booking_status_label($code);
+    return '<span class="badge ' . htmlspecialchars($class, ENT_QUOTES, 'UTF-8') . '">' . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '</span>';
 }
 ?>
 
@@ -261,7 +253,7 @@ function getStatusBadge($status) {
                                                     <div class="mb-2">
                                                         <?= getStatusBadge($booking['status']) ?>
                                                     </div>
-                                                    <?php if ($booking['status'] === 'pending'): ?>
+                                                    <?php if (booking_status_code($booking['status']) === BOOKING_STATUS_PENDING): ?>
                                                         <small class="text-muted">
                                                             <i class="fas fa-info-circle me-1"></i>
                                                             Waiting for confirmation

--- a/new2/submit_booking.php
+++ b/new2/submit_booking.php
@@ -2,6 +2,8 @@
 session_start();
 header('Content-Type: application/json; charset=utf-8');
 
+require_once __DIR__ . '/../booking_status.php';
+
 try {
     $pdo = new PDO("mysql:host=127.0.0.1;dbname=first9;charset=utf8mb4", "root", "", [
         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
@@ -126,7 +128,7 @@ try {
     // Insert into booking with evidence
     $stmt = $pdo->prepare("
         INSERT INTO booking (customer_id, staff_id, booking_date, time_start, time_end, total_price, total_discount, final_price, status, discount_detail, evidence)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ");
     $stmt->execute([
         $customer_id, 
@@ -136,7 +138,8 @@ try {
         $end_time, 
         $total_price, 
         $total_discount, 
-        $final_price, 
+        $final_price,
+        BOOKING_STATUS_PENDING,
         null,
         $evidenceFileName
     ]);


### PR DESCRIPTION
## Summary
- add a shared `booking_status.php` helper to map booking status codes, text, and badge classes
- migrate admin booking flows (reports, dashboards, APIs, and mutations) to rely on the numeric status codes and helper utilities
- update customer booking submission and profile pages to persist and render the new status codes consistently

## Testing
- php -l booking_status.php
- php -l Admin/connect_db.php
- php -l Admin/booking_detail.php
- php -l Admin/update_booking_status.php
- php -l Admin/insert_booking.php
- php -l Admin/report_booking.php
- php -l Admin/report_service.php
- php -l Admin/report_staff.php
- php -l Admin/report_income.php
- php -l Admin/customer_bookings.php
- php -l Admin/schedule.php
- php -l Admin/index.php
- php -l Admin/api/available_staff.php
- php -l Admin/submit_booking.php
- php -l Admin/booking_delete.php
- php -l new2/connect_db.php
- php -l new2/submit_booking.php
- php -l new2/profileuser.php
- php -l new2/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d2ca6a81a0832d962da9c11ffcc7b1