### PR TITLE
Refine admin booking layout for improved usability

### DIFF
--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -127,8 +127,8 @@
           <div class="card-body p-0">
 
             <form id="bookingForm" action="submit_booking.php" method="POST" enctype="multipart/form-data">
-              <div class="row g-4">
-                <div class="col-lg-8 d-flex flex-column gap-4">
+              <div class="row g-3">
+                <div class="col-lg-8 d-flex flex-column gap-3">
                   <div class="card shadow-sm border-0">
                     <div class="card-body">
                       <h5 class="card-title mb-3">Customer</h5>
@@ -204,7 +204,7 @@
                 </div>
 
                 <div class="col-lg-4">
-                  <div class="d-flex flex-column gap-4 sticky-lg-top" style="top: 5.5rem;">
+                  <div class="d-flex flex-column gap-3 sticky-lg-top" style="top: 5.5rem;">
                     <div class="card shadow-sm summary-card border-0">
                       <div class="card-body">
                         <h5 class="card-title mb-3">Price Summary</h5>
@@ -432,11 +432,10 @@
         .then(options => {
           options.forEach(o => {
             const opt = document.createElement('option');
-            const priceValue = parseFloat(o.price);
             opt.value = o.option_id;
             opt.dataset.duration = o.duration;
             opt.dataset.price = o.price;
-            opt.textContent = `${o.duration} minutes${!isNaN(priceValue) ? ` - €${priceValue.toFixed(2)}` : ''}`;
+            opt.textContent = `${o.duration} minutes`;
             optionSelect.appendChild(opt);
           });
           // หลังโหลดตัวเลือก เสนอให้ผู้ใช้เลือกเอง → แค่รีเฟรชสรุปเวลาราคา

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -133,52 +133,10 @@
                 <div class="col-lg-8 d-flex flex-column gap-4">
                   <div class="card shadow-sm border-0">
                     <div class="card-body">
-                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
-                        <div>
-                          <h5 class="card-title mb-1">Customer &amp; Schedule</h5>
-                          <p class="form-section-description mb-0">Choose the customer and set the details for this appointment.</p>
-                        </div>
-                      </div>
-                      <div class="row g-3">
-                        <div class="col-12">
-                          <label for="customer" class="form-label">Select Customer</label>
-                          <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
-                            <option value="">Select a customer</option>
-                            <?php foreach ($customers as $customer) { ?>
-                              <option value="<?php echo htmlspecialchars($customer['customer_id']); ?>"><?php echo htmlspecialchars($customer['customer_id'] . ' - ' . $customer['customer_name']); ?></option>
-                            <?php } ?>
-                          </select>
-                        </div>
-                        <div class="col-sm-6">
-                          <label for="bookingDate" class="form-label">Select Date</label>
-                          <input type="text" class="form-control" id="bookingDate" name="booking_date" required>
-                        </div>
-                        <div class="col-sm-6">
-                          <label for="startTime" class="form-label">Select Start Time</label>
-                          <select class="form-select" id="startTime" name="start_time" onchange="loadAvailableStaff()" required>
-                            <option value="">Select a time</option>
-                          </select>
-                        </div>
-                        <div class="col-sm-6">
-                          <label for="staff" class="form-label">Select Staff</label>
-                          <select class="form-select" id="staff" name="staff_id" required>
-                            <option value="">Select a staff member</option>
-                          </select>
-                        </div>
-                        <div class="col-sm-6 col-lg-4">
-                          <label class="form-label">Total Duration</label>
-                          <input type="text" class="form-control" id="totalDuration" value="0 minutes" readonly>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div class="card shadow-sm border-0">
-                    <div class="card-body">
                       <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
                         <div>
                           <h5 class="card-title mb-1">Services</h5>
-                          <p class="form-section-description mb-0">Add each service required for this booking. You can add more than one option.</p>
+                          <p class="form-section-description mb-0">Start by selecting the services required for this booking. You can add more than one option.</p>
                         </div>
                         <button type="button" class="btn btn-outline-primary btn-sm" onclick="addService()">Add Service</button>
                       </div>
@@ -213,6 +171,44 @@
                       </div>
                     </div>
                   </div>
+
+                  <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
+                        <div>
+                          <h5 class="card-title mb-1">Customer &amp; Schedule</h5>
+                          <p class="form-section-description mb-0">After selecting services, choose the customer and suitable time slot.</p>
+                        </div>
+                      </div>
+                      <div class="row g-3">
+                        <div class="col-12">
+                          <label for="customer" class="form-label">Select Customer</label>
+                          <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
+                            <option value="">Select a customer</option>
+                            <?php foreach ($customers as $customer) { ?>
+                              <option value="<?php echo htmlspecialchars($customer['customer_id']); ?>"><?php echo htmlspecialchars($customer['customer_id'] . ' - ' . $customer['customer_name']); ?></option>
+                            <?php } ?>
+                          </select>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="bookingDate" class="form-label">Select Date</label>
+                          <input type="text" class="form-control" id="bookingDate" name="booking_date" required disabled>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="startTime" class="form-label">Select Start Time</label>
+                          <select class="form-select" id="startTime" name="start_time" onchange="loadAvailableStaff()" required disabled>
+                            <option value="">Select a time</option>
+                          </select>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="staff" class="form-label">Select Staff</label>
+                          <select class="form-select" id="staff" name="staff_id" required disabled>
+                            <option value="">Select a staff member</option>
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
 
                 <div class="col-lg-4">
@@ -220,6 +216,10 @@
                     <div class="card shadow-sm summary-card border-0">
                       <div class="card-body">
                         <h5 class="card-title mb-3">Price Summary</h5>
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                          <span class="text-muted text-uppercase small">Total Duration</span>
+                          <span id="totalDurationDisplay" class="fw-semibold">0 minutes</span>
+                        </div>
                         <div class="table-responsive">
                           <table class="table table-sm align-middle mb-0">
                             <thead class="table-light">
@@ -291,6 +291,10 @@
     const fileInput = document.getElementById('imgprofile');
     const previewImage = document.getElementById('previewImage');
     const uploadText = document.getElementById('uploadText');
+    const bookingDateInput = document.getElementById('bookingDate');
+    const startTimeSelect = document.getElementById('startTime');
+    const staffSelect = document.getElementById('staff');
+    let bookingDatePicker;
 
     uploadBox.addEventListener('dragover', (e) => {
       e.preventDefault(); uploadBox.classList.add('dragover');
@@ -313,17 +317,43 @@
       if (customerSelect) {
         $(customerSelect).select2({ placeholder: "Search or select a customer", allowClear: true });
       }
+
+      bookingDatePicker = flatpickr("#bookingDate", {
+        dateFormat: "Y-m-d",
+        minDate: "today",
+        clickOpens: false,
+        onChange: function(selectedDates, dateStr){
+          loadAvailableTimes(dateStr);
+          calculatePrices();
+        }
+      });
+
+      updateScheduleAvailability(false);
     });
 
-    // ---------- Flatpickr ----------
-    flatpickr("#bookingDate", {
-      dateFormat: "Y-m-d",
-      minDate: "today",
-      onChange: function(selectedDates, dateStr){
-        loadAvailableTimes(dateStr);
-        calculatePrices();
+    function updateScheduleAvailability(hasDuration){
+      if (!bookingDateInput || !startTimeSelect || !staffSelect) { return; }
+
+      if (!hasDuration) {
+        if (bookingDatePicker) {
+          bookingDatePicker.clear();
+          bookingDatePicker.set('clickOpens', false);
+        }
+        bookingDateInput.value = '';
+        bookingDateInput.setAttribute('disabled', 'disabled');
+
+        startTimeSelect.innerHTML = '<option value="">Select a time</option>';
+        startTimeSelect.setAttribute('disabled', 'disabled');
+
+        staffSelect.innerHTML = '<option value="">Select a staff member</option>';
+        staffSelect.setAttribute('disabled', 'disabled');
+      } else {
+        bookingDateInput.removeAttribute('disabled');
+        if (bookingDatePicker) {
+          bookingDatePicker.set('clickOpens', true);
+        }
       }
-    });
+    }
 
     // ---------- Helpers ----------
     function getTotalMinutes(){
@@ -337,8 +367,12 @@
 
     function refreshTotalDuration(){
       const mins = getTotalMinutes();
-      document.getElementById('totalDuration').value = `${mins} minutes`;
-      const date = document.getElementById('bookingDate').value;
+      const durationDisplay = document.getElementById('totalDurationDisplay');
+      if (durationDisplay) {
+        durationDisplay.textContent = `${mins} minutes`;
+      }
+      updateScheduleAvailability(mins > 0);
+      const date = bookingDateInput ? bookingDateInput.value : '';
       if (date) loadAvailableTimes(date); // refresh slots when minutes change
     }
 
@@ -421,8 +455,14 @@
     // ---------- Time slots ----------
     function loadAvailableTimes(date){
       const totalDuration = getTotalMinutes();
-      const timeSelect = document.getElementById('startTime');
-      timeSelect.innerHTML = '<option value="">Select a time</option>';
+
+      if (!startTimeSelect || !staffSelect) { return; }
+
+      startTimeSelect.innerHTML = '<option value="">Select a time</option>';
+      startTimeSelect.setAttribute('disabled', 'disabled');
+
+      staffSelect.innerHTML = '<option value="">Select a staff member</option>';
+      staffSelect.setAttribute('disabled', 'disabled');
 
       if (!date || !totalDuration){ return; }
 
@@ -432,8 +472,13 @@
           times.forEach(t => {
             const o = document.createElement('option');
             o.value = t; o.textContent = t;
-            timeSelect.appendChild(o);
+            startTimeSelect.appendChild(o);
           });
+
+          if (times.length) {
+            startTimeSelect.removeAttribute('disabled');
+          }
+
           loadAvailableStaff();
         })
         .catch(() => {});
@@ -441,11 +486,13 @@
 
     // ---------- Staff ----------
     function loadAvailableStaff(){
-      const date = document.getElementById('bookingDate').value;
-      const startTime = document.getElementById('startTime').value;
+      if (!staffSelect) { return; }
+
+      const date = bookingDateInput ? bookingDateInput.value : '';
+      const startTime = startTimeSelect ? startTimeSelect.value : '';
       const totalDuration = getTotalMinutes();
-      const staffSelect = document.getElementById('staff');
       staffSelect.innerHTML = '<option value="">Select a staff member</option>';
+      staffSelect.setAttribute('disabled', 'disabled');
 
       if (date && startTime && totalDuration){
         fetch(`get_available_staff.php?date=${encodeURIComponent(date)}&start_time=${encodeURIComponent(startTime)}&duration=${encodeURIComponent(totalDuration)}`)
@@ -456,6 +503,10 @@
               o.value = s.staff_id; o.textContent = s.staff_name;
               staffSelect.appendChild(o);
             });
+
+            if (staffs.length) {
+              staffSelect.removeAttribute('disabled');
+            }
           })
           .catch(() => {});
       }

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -63,10 +63,10 @@
     .upload-box {
       border: 2px dashed #ced4da;
       border-radius: 12px;
-      padding: 20px;
+      padding: 16px;
       text-align: center;
       position: relative;
-      min-height: 180px;
+      min-height: 140px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -89,13 +89,13 @@
     #previewImage {
       display: none;
       max-width: 100%;
-      max-height: 240px;
+      max-height: 200px;
       object-fit: contain;
     }
 
     #uploadText {
       color: #6c757d;
-      font-size: 0.95rem;
+      font-size: 0.85rem;
     }
 
     @media (max-width: 991.98px) {
@@ -263,7 +263,7 @@
                 </div>
 
                 <div class="col-12 d-flex justify-content-end">
-                  <button type="submit" class="btn btn-primary btn-lg px-4 mt-2 mt-lg-0">Confirm Booking</button>
+                  <button type="submit" class="btn btn-primary px-4 py-2 mt-2 mt-lg-0">Confirm Booking</button>
                 </div>
               </div>
             </form>

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -14,6 +14,9 @@
   <!-- Select2 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+
   <style>
     body {
       background-color: #f5f7fb;
@@ -160,7 +163,9 @@
                               </select>
                             </div>
                             <div class="col-12 col-md-3 col-lg-2 col-xl-1">
-                              <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-service" onclick="removeService(this)">Remove</button>
+                              <button type="button" class="btn btn-outline-danger btn-sm d-flex align-items-center justify-content-center w-100 remove-service" onclick="removeService(this)" aria-label="Remove service">
+                                <i class="bi bi-x-lg"></i>
+                              </button>
                             </div>
                           </div>
                         </div>
@@ -216,10 +221,6 @@
                     <div class="card shadow-sm summary-card border-0">
                       <div class="card-body">
                         <h5 class="card-title mb-3">Price Summary</h5>
-                        <div class="d-flex justify-content-between align-items-center mb-3">
-                          <span class="text-muted text-uppercase small">Total Duration</span>
-                          <span id="totalDurationDisplay" class="fw-semibold">0 minutes</span>
-                        </div>
                         <div class="table-responsive">
                           <table class="table table-sm align-middle mb-0">
                             <thead class="table-light">
@@ -235,6 +236,10 @@
                               </tr>
                             </tbody>
                             <tfoot>
+                              <tr>
+                                <th colspan="2" class="text-muted text-uppercase small">Total Duration</th>
+                                <th id="totalDurationDisplay" class="text-end text-muted small">0 minutes</th>
+                              </tr>
                               <tr>
                                 <th colspan="2">Total</th>
                                 <th id="totalPrice" class="text-end">€0.00</th>
@@ -404,7 +409,9 @@
             </select>
           </div>
           <div class="col-12 col-md-3 col-lg-2 col-xl-1">
-            <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-service" onclick="removeService(this)">Remove</button>
+            <button type="button" class="btn btn-outline-danger btn-sm d-flex align-items-center justify-content-center w-100 remove-service" onclick="removeService(this)" aria-label="Remove service">
+              <i class="bi bi-x-lg"></i>
+            </button>
           </div>
         </div>`;
       container.appendChild(newRow);
@@ -439,10 +446,11 @@
         .then(options => {
           options.forEach(o => {
             const opt = document.createElement('option');
+            const priceValue = parseFloat(o.price);
             opt.value = o.option_id;
             opt.dataset.duration = o.duration;
             opt.dataset.price = o.price;
-            opt.textContent = `${o.duration} minutes (€${o.price})`;
+            opt.textContent = `${o.duration} minutes${!isNaN(priceValue) ? ` - €${priceValue.toFixed(2)}` : ''}`;
             optionSelect.appendChild(opt);
           });
           // หลังโหลดตัวเลือก เสนอให้ผู้ใช้เลือกเอง → แค่รีเฟรชสรุปเวลาราคา
@@ -583,7 +591,7 @@
 
           let priceCell = `<span class="fw-semibold">€${price.toFixed(2)}</span>`;
           if (discountAmount > 0){
-            priceCell = `<span class="fw-semibold text-success">€${finalPrice.toFixed(2)}</span><div class="text-muted small">Saved €${discountAmount.toFixed(2)} (was €${price.toFixed(2)})</div>`;
+            priceCell = `<span class="fw-semibold text-success d-block">€${finalPrice.toFixed(2)}</span><span class="text-muted text-decoration-line-through small d-block">€${price.toFixed(2)}</span>`;
           }
 
           priceTable.insertAdjacentHTML('beforeend', `

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -409,41 +409,45 @@
       option.dataset.discountAmount = resolvedDiscount.toFixed(2);
     }
 
-    async function applyOptionDiscountLabels(selectEl){
-      if (!selectEl){ return; }
+ async function applyOptionDiscountLabels(selectEl){
+   if (!selectEl){ return; }
 
-      const optionElements = Array.from(selectEl.options).filter(opt => Number.parseInt(opt.value || '0', 10) > 0);
-      optionElements.forEach(opt => setOptionDisplay(opt, null));
+   const optionElements = Array.from(selectEl.options).filter(opt => Number.parseInt(opt.value || '0', 10) > 0);
+   optionElements.forEach(opt => setOptionDisplay(opt, null));
 
-      if (!optionElements.length){
-        calculatePrices();
-        return;
-      }
+   if (!optionElements.length){
+-    calculatePrices();
++    calculatePrices();
++    refreshOptionDropdown(selectEl);
+     return;
+   }
 
-      const optionIds = optionElements.map(opt => Number.parseInt(opt.value, 10));
-      const { date, time } = getCurrentBookingMoment();
+   const optionIds = optionElements.map(opt => Number.parseInt(opt.value, 10));
+   const { date, time } = getCurrentBookingMoment();
 
-      try {
-        const response = await fetch('get_applicable_promotions.php', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ option_ids: optionIds, date, time })
-        });
+   try {
+     const response = await fetch('get_applicable_promotions.php', {
+       method: 'POST',
+       headers: { 'Content-Type': 'application/json' },
+       body: JSON.stringify({ option_ids: optionIds, date, time })
+     });
 
-        if (response.ok){
-          const data = await response.json();
-          const discountMap = (data && typeof data === 'object') ? (data.option_discounts || {}) : {};
-          optionElements.forEach(opt => {
-            const optionId = Number.parseInt(opt.value, 10);
-            setOptionDisplay(opt, discountMap[optionId] || null);
-          });
-        }
-      } catch (error) {
-        console.warn('Failed to load option discount details', error);
-      } finally {
-        calculatePrices();
-      }
-    }
+     if (response.ok){
+       const data = await response.json();
+       const discountMap = (data && typeof data === 'object') ? (data.option_discounts || {}) : {};
+       optionElements.forEach(opt => {
+         const optionId = Number.parseInt(opt.value, 10);
+         setOptionDisplay(opt, discountMap[optionId] || null);
+       });
+     }
+   } catch (error) {
+     console.warn('Failed to load option discount details', error);
+   } finally {
+     calculatePrices();
++    // หลังอัปเดตราคาใน data-* แล้ว ให้ Select2 วาดใหม่ เพื่อให้เส้นขีดทับขึ้นถูกต้อง
++    refreshOptionDropdown(selectEl);
+   }
+ }
 
     // ---------- Select2 for customer ----------
     document.addEventListener('DOMContentLoaded', function () {
@@ -559,35 +563,35 @@
 
     // ---------- Load options for a given service (row-relative) ----------
     function loadOptions(serviceSelectEl){
-      const row = serviceSelectEl.closest('.service-row');
-      const optionSelect = row.querySelector('.option-select');
-      const serviceId = serviceSelectEl.value;
+   const row = serviceSelectEl.closest('.service-row');
+   const optionSelect = row.querySelector('.option-select');
+   const serviceId = serviceSelectEl.value;
 
-      optionSelect.innerHTML = '<option value="">Select an option</option>';
-      refreshTotalDuration();
-      calculatePrices();
-      if (!serviceId){
-        return;
-      }
+   optionSelect.innerHTML = '<option value="">Select an option</option>';
+   refreshTotalDuration();
+   calculatePrices();
+   if (!serviceId){ return; }
 
-      fetch(`get_options.php?service_id=${encodeURIComponent(serviceId)}`)
-        .then(res => res.json())
-        .then(options => {
-          options.forEach(o => {
-            const opt = document.createElement('option');
-            opt.value = o.option_id;
-            opt.dataset.duration = o.duration;
-            opt.dataset.price = o.price;
-            opt.textContent = buildOptionLabel(o.duration, o.price, null);
-            optionSelect.appendChild(opt);
-          });
-          applyOptionDiscountLabels(optionSelect);
-          // หลังโหลดตัวเลือก เสนอให้ผู้ใช้เลือกเอง → แค่รีเฟรชสรุปเวลาราคา
-          refreshTotalDuration();
-        })
-        .catch(() => { /* เงียบไว้ก่อน หรือจะแจ้ง error ก็ได้ */ });
-    }
-
+   fetch(`get_options.php?service_id=${encodeURIComponent(serviceId)}`)
+     .then(res => res.json())
+     .then(options => {
+       options.forEach(o => {
+         const opt = document.createElement('option');
+         opt.value = o.option_id;
+         opt.dataset.duration = o.duration;
+         opt.dataset.price = o.price;
+         // ปล่อย text ธรรมดาไว้เป็น fallback
+         opt.textContent = buildOptionLabel(o.duration, o.price, null);
+         optionSelect.appendChild(opt);
+       });
+       applyOptionDiscountLabels(optionSelect);
++      // ใช้ Select2 กับ dropdown นี้
++      enhanceOptionDropdown(optionSelect);
+       refreshTotalDuration();
+     })
+     .catch(() => {});
+ }
+ 
     // ---------- Time slots ----------
     function loadAvailableTimes(date){
       const totalDuration = getTotalMinutes();
@@ -741,6 +745,66 @@
         }
       }
     }
+
+    function enhanceOptionDropdown(selectEl){
+    if (!selectEl) return;
+    const $el = $(selectEl);
+    // ถ้าเคย init แล้ว ให้ destroy ก่อน
+    if ($el.data('select2')) { $el.select2('destroy'); }
+
+    $el.select2({
+      width: '100%',
+      // แสดงรายการใน dropdown
+      templateResult: function (state) {
+        if (!state.id) return state.text;
+        const opt = state.element;
+        const base = parseFloat(opt.dataset.price || '');
+        const final = parseFloat(opt.dataset.finalPrice || '');
+        const dur   = parseInt(opt.dataset.duration || '', 10);
+        const hasDiscount = Number.isFinite(base) && Number.isFinite(final) && final < base;
+
+        const durationText = Number.isFinite(dur) && dur > 0 ? dur + ' minutes' : '';
+        const priceHtml = hasDiscount
+          ? `<span style="margin-right:.5rem;">€${final.toFixed(2)}</span>
+             <span style="text-decoration:line-through;opacity:.6;">€${base.toFixed(2)}</span>`
+          : (Number.isFinite(base) ? `€${base.toFixed(2)}` : '');
+
+        return $(
+          `<div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+             <span>${durationText}</span>
+             <span>${priceHtml}</span>
+           </div>`
+        );
+      },
+      // ข้อความเมื่อเลือกแล้ว (บริเวณกล่อง select)
+      templateSelection: function (state) {
+        if (!state.id) return state.text;
+        const opt = state.element;
+        const base = parseFloat(opt.dataset.price || '');
+        const final = parseFloat(opt.dataset.finalPrice || '');
+        const dur   = parseInt(opt.dataset.duration || '', 10);
+        const hasDiscount = Number.isFinite(base) && Number.isFinite(final) && final < base;
+
+        const durationText = Number.isFinite(dur) && dur > 0 ? dur + ' minutes' : 'Option';
+        return hasDiscount
+          ? `${durationText} – €${final.toFixed(2)} (was €${base.toFixed(2)})`
+          : (Number.isFinite(base) ? `${durationText} – €${base.toFixed(2)}` : durationText);
+      },
+      // อนุญาต HTML
+      escapeMarkup: function (m) { return m; }
+    });
+  }
+
+  // ให้ Select2 รีเพนท์หลังจากที่เราอัปเดต data-* ของ <option>
+  function refreshOptionDropdown(selectEl){
+    const $el = $(selectEl);
+    if ($el.data('select2')) {
+      // ทริกเกอร์ให้ select2 อ่านค่าใหม่ แล้ววาดใหม่
+      $el.trigger('change.select2');
+    } else {
+      enhanceOptionDropdown(selectEl);
+    }
+  }
   </script>
 </main>
 </body>

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -40,6 +40,10 @@
       margin-top: 0;
     }
 
+    .compact-card .card-body {
+      padding: 1.25rem;
+    }
+
     .summary-card .table {
       font-size: 0.95rem;
     }
@@ -127,11 +131,11 @@
           <div class="card-body p-0">
 
             <form id="bookingForm" action="submit_booking.php" method="POST" enctype="multipart/form-data">
-              <div class="row g-3">
-                <div class="col-lg-8 d-flex flex-column gap-3">
-                  <div class="card shadow-sm border-0">
+              <div class="row g-2">
+                <div class="col-lg-8 d-flex flex-column gap-2">
+                  <div class="card shadow-sm border-0 compact-card">
                     <div class="card-body">
-                      <h5 class="card-title mb-3">Customer</h5>
+                      <h5 class="card-title mb-2">Customer</h5>
                       <label for="customer" class="form-label">Select Customer</label>
                       <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
                         <option value="">Select a customer</option>
@@ -142,16 +146,16 @@
                     </div>
                   </div>
 
-                  <div class="card shadow-sm border-0">
+                  <div class="card shadow-sm border-0 compact-card">
                     <div class="card-body">
-                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-2">
                         <h5 class="card-title mb-0">Services</h5>
                         <button type="button" class="btn btn-outline-primary btn-sm" onclick="addService()">Add Service</button>
                       </div>
 
-                      <div id="servicesContainer" class="d-flex flex-column gap-3">
-                        <div class="service-row p-3">
-                          <div class="row g-3 align-items-end">
+                      <div id="servicesContainer" class="d-flex flex-column gap-2">
+                        <div class="service-row p-2">
+                          <div class="row g-2 align-items-end">
                             <div class="col-12 col-md-6">
                               <label class="form-label">Select Service</label>
                               <select class="form-select service-select" name="services[]" onchange="loadOptions(this)">
@@ -178,10 +182,10 @@
                     </div>
                   </div>
 
-                  <div class="card shadow-sm border-0">
+                  <div class="card shadow-sm border-0 compact-card">
                     <div class="card-body">
-                      <h5 class="card-title mb-3">Schedule</h5>
-                      <div class="row g-3">
+                      <h5 class="card-title mb-2">Schedule</h5>
+                      <div class="row g-2">
                         <div class="col-sm-6">
                           <label for="bookingDate" class="form-label">Select Date</label>
                           <input type="text" class="form-control" id="bookingDate" name="booking_date" required disabled>
@@ -204,10 +208,10 @@
                 </div>
 
                 <div class="col-lg-4">
-                  <div class="d-flex flex-column gap-3 sticky-lg-top" style="top: 5.5rem;">
-                    <div class="card shadow-sm summary-card border-0">
+                  <div class="d-flex flex-column gap-2 sticky-lg-top" style="top: 5.5rem;">
+                    <div class="card shadow-sm summary-card border-0 compact-card">
                       <div class="card-body">
-                        <h5 class="card-title mb-3">Price Summary</h5>
+                        <h5 class="card-title mb-2">Price Summary</h5>
                         <div class="table-responsive">
                           <table class="table table-sm align-middle mb-0">
                             <thead class="table-light">
@@ -245,9 +249,9 @@
                       </div>
                     </div>
 
-                    <div class="card shadow-sm border-0">
+                    <div class="card shadow-sm border-0 compact-card">
                       <div class="card-body">
-                        <h5 class="card-title mb-3">Supporting Evidence</h5>
+                        <h5 class="card-title mb-2">Supporting Evidence</h5>
                         <div class="upload-box" id="uploadBox">
                           <div class="upload-text" id="uploadText">Add evidence (JPG, PNG, PDF)</div>
                           <input type="file" id="imgprofile" name="imgprofile" />
@@ -259,7 +263,7 @@
                 </div>
 
                 <div class="col-12 d-flex justify-content-end">
-                  <button type="submit" class="btn btn-primary btn-lg px-4 mt-3 mt-lg-0">Confirm Booking</button>
+                  <button type="submit" class="btn btn-primary btn-lg px-4 mt-2 mt-lg-0">Confirm Booking</button>
                 </div>
               </div>
             </form>
@@ -376,9 +380,9 @@
     function addService(){
       const container = document.getElementById('servicesContainer');
       const newRow = document.createElement('div');
-      newRow.className = 'service-row p-3';
+      newRow.className = 'service-row p-2';
       newRow.innerHTML = `
-        <div class="row g-3 align-items-end">
+        <div class="row g-2 align-items-end">
           <div class="col-12 col-md-6">
             <label class="form-label">Select Service</label>
             <select class="form-select service-select" name="services[]" onchange="loadOptions(this)">

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -15,14 +15,92 @@
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 
   <style>
-    .upload-box{
-      border:2px dashed #ced4da; border-radius:8px; padding:16px; text-align:center; position:relative;
-      min-height:150px; display:flex; align-items:center; justify-content:center; background:#fff;
+    body {
+      background-color: #f5f7fb;
     }
-    .upload-box.dragover{ background:#f8f9fa; border-color:#0d6efd; }
-    .upload-box input[type="file"]{ position:absolute; inset:0; opacity:0; cursor:pointer; }
-    #previewImage{ display:none; max-width:100%; max-height:260px; }
-    #uploadText{ color:#6c757d; }
+
+    .card h5.card-title {
+      font-weight: 600;
+    }
+
+    .form-section-description {
+      font-size: 0.9rem;
+      color: #6c757d;
+    }
+
+    .service-row {
+      border: 1px dashed #ced4da;
+      border-radius: 12px;
+      background: rgba(13, 110, 253, 0.03);
+    }
+
+    .service-row .form-label {
+      font-weight: 500;
+    }
+
+    .service-row .remove-service {
+      margin-top: 0;
+    }
+
+    .summary-card .table {
+      font-size: 0.95rem;
+    }
+
+    .summary-card .table tbody td {
+      vertical-align: middle;
+    }
+
+    .summary-card .table tfoot th {
+      font-weight: 600;
+    }
+
+    .summary-card .table tfoot th:last-child {
+      font-size: 1rem;
+    }
+
+    .upload-box {
+      border: 2px dashed #ced4da;
+      border-radius: 12px;
+      padding: 20px;
+      text-align: center;
+      position: relative;
+      min-height: 180px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #fff;
+      transition: all 0.2s ease-in-out;
+    }
+
+    .upload-box.dragover {
+      background: #f1f5ff;
+      border-color: #0d6efd;
+    }
+
+    .upload-box input[type="file"] {
+      position: absolute;
+      inset: 0;
+      opacity: 0;
+      cursor: pointer;
+    }
+
+    #previewImage {
+      display: none;
+      max-width: 100%;
+      max-height: 240px;
+      object-fit: contain;
+    }
+
+    #uploadText {
+      color: #6c757d;
+      font-size: 0.95rem;
+    }
+
+    @media (max-width: 991.98px) {
+      .sticky-lg-top {
+        position: static !important;
+      }
+    }
   </style>
 </head>
 
@@ -30,6 +108,12 @@
 <?php $pdo = new PDO("mysql:host=127.0.0.1;dbname=first9", "root", ""); ?>
 <?php include("header.php"); ?>
 <?php include("slidebar.php"); ?>
+<?php
+  $customers = $pdo->query("SELECT customer_id, customer_name FROM customer ORDER BY customer_name")
+                   ->fetchAll(PDO::FETCH_ASSOC);
+  $services = $pdo->query("SELECT service_id, service_name FROM service WHERE is_active = 1 ORDER BY service_name")
+                  ->fetchAll(PDO::FETCH_ASSOC);
+?>
 
 <main id="main" class="main pt-5 mt-5">
 
@@ -41,122 +125,152 @@
   <section class="section">
     <div class="row">
       <div class="col-lg-12">
-        <div class="card">
-          <div class="card-body">
+        <div class="card border-0 shadow-none bg-transparent">
+          <div class="card-body p-0">
 
             <form id="bookingForm" action="submit_booking.php" method="POST" enctype="multipart/form-data">
-
-              <!-- Customer -->
-              <div class="mb-3">
-                <label for="customer" class="form-label">Select Customer</label>
-                <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
-                  <option value="">Select a customer</option>
-                  <?php
-                    $customers = $pdo->query("SELECT customer_id, customer_name FROM customer")->fetchAll(PDO::FETCH_ASSOC);
-                    foreach ($customers as $customer) {
-                      echo "<option value='{$customer['customer_id']}'>{$customer['customer_id']} - {$customer['customer_name']}</option>";
-                    }
-                  ?>
-                </select>
-              </div>
-
-              <!-- Services -->
-              <div id="servicesContainer">
-                <div class="service-row card p-3 mb-3">
-                  <div class="row">
-                    <div class="col-md-6">
-                      <label class="form-label">Select Service</label>
-                      <select class="form-select service-select" name="services[]" onchange="loadOptions(this)">
-                        <option value="">Select a service</option>
-                        <?php
-                          $services = $pdo->query("SELECT service_id, service_name FROM service WHERE is_active = 1")->fetchAll(PDO::FETCH_ASSOC);
-                          foreach ($services as $service) {
-                            echo "<option value='{$service['service_id']}'>{$service['service_name']}</option>";
-                          }
-                        ?>
-                      </select>
+              <div class="row g-4">
+                <div class="col-lg-8 d-flex flex-column gap-4">
+                  <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
+                        <div>
+                          <h5 class="card-title mb-1">Customer &amp; Schedule</h5>
+                          <p class="form-section-description mb-0">Choose the customer and set the details for this appointment.</p>
+                        </div>
+                      </div>
+                      <div class="row g-3">
+                        <div class="col-12">
+                          <label for="customer" class="form-label">Select Customer</label>
+                          <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
+                            <option value="">Select a customer</option>
+                            <?php foreach ($customers as $customer) { ?>
+                              <option value="<?php echo htmlspecialchars($customer['customer_id']); ?>"><?php echo htmlspecialchars($customer['customer_id'] . ' - ' . $customer['customer_name']); ?></option>
+                            <?php } ?>
+                          </select>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="bookingDate" class="form-label">Select Date</label>
+                          <input type="text" class="form-control" id="bookingDate" name="booking_date" required>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="startTime" class="form-label">Select Start Time</label>
+                          <select class="form-select" id="startTime" name="start_time" onchange="loadAvailableStaff()" required>
+                            <option value="">Select a time</option>
+                          </select>
+                        </div>
+                        <div class="col-sm-6">
+                          <label for="staff" class="form-label">Select Staff</label>
+                          <select class="form-select" id="staff" name="staff_id" required>
+                            <option value="">Select a staff member</option>
+                          </select>
+                        </div>
+                        <div class="col-sm-6 col-lg-4">
+                          <label class="form-label">Total Duration</label>
+                          <input type="text" class="form-control" id="totalDuration" value="0 minutes" readonly>
+                        </div>
+                      </div>
                     </div>
-                    <div class="col-md-5">
-                      <label class="form-label">Select Option</label>
-                      <select class="form-select option-select" name="options[]" onchange="onOptionChange(this)">
-                        <option value="">Select an option</option>
-                      </select>
-                    </div>
-                    <div class="col-md-1">
-                      <button type="button" class="btn btn-danger mt-4" onclick="removeService(this)">X</button>
+                  </div>
+
+                  <div class="card shadow-sm border-0">
+                    <div class="card-body">
+                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+                        <div>
+                          <h5 class="card-title mb-1">Services</h5>
+                          <p class="form-section-description mb-0">Add each service required for this booking. You can add more than one option.</p>
+                        </div>
+                        <button type="button" class="btn btn-outline-primary btn-sm" onclick="addService()">Add Service</button>
+                      </div>
+
+                      <div id="servicesContainer" class="d-flex flex-column gap-3">
+                        <div class="service-row p-3">
+                          <div class="row g-3 align-items-end">
+                            <div class="col-12 col-md-6">
+                              <label class="form-label">Select Service</label>
+                              <select class="form-select service-select" name="services[]" onchange="loadOptions(this)">
+                                <option value="">Select a service</option>
+                                <?php foreach ($services as $service) { ?>
+                                  <option value="<?php echo htmlspecialchars($service['service_id']); ?>"><?php echo htmlspecialchars($service['service_name']); ?></option>
+                                <?php } ?>
+                              </select>
+                            </div>
+                            <div class="col-12 col-md-5">
+                              <label class="form-label">Select Option</label>
+                              <select class="form-select option-select" name="options[]" onchange="onOptionChange(this)">
+                                <option value="">Select an option</option>
+                              </select>
+                            </div>
+                            <div class="col-12 col-md-3 col-lg-2 col-xl-1">
+                              <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-service" onclick="removeService(this)">Remove</button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="alert alert-info mt-4 mb-0 small" role="alert">
+                        Total duration and price summary will update automatically when you choose service options.
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
 
-              <button type="button" class="btn btn-primary mb-3" onclick="addService()">Add Another Service</button>
+                <div class="col-lg-4">
+                  <div class="d-flex flex-column gap-4 sticky-lg-top" style="top: 5.5rem;">
+                    <div class="card shadow-sm summary-card border-0">
+                      <div class="card-body">
+                        <h5 class="card-title mb-3">Price Summary</h5>
+                        <div class="table-responsive">
+                          <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                              <tr>
+                                <th>Service</th>
+                                <th>Option</th>
+                                <th class="text-end">Price (€)</th>
+                              </tr>
+                            </thead>
+                            <tbody id="priceTable">
+                              <tr>
+                                <td colspan="3" class="text-center text-muted py-4">Select service options to see pricing.</td>
+                              </tr>
+                            </tbody>
+                            <tfoot>
+                              <tr>
+                                <th colspan="2">Total</th>
+                                <th id="totalPrice" class="text-end">€0.00</th>
+                              </tr>
+                              <tr>
+                                <th colspan="2">Discount</th>
+                                <th id="discountAmount" class="text-end">-€0.00</th>
+                              </tr>
+                              <tr>
+                                <th colspan="2">Final Price</th>
+                                <th id="finalPrice" class="text-end">€0.00</th>
+                              </tr>
+                            </tfoot>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
 
-              <!-- Total Duration -->
-              <div class="mb-3">
-                <label class="form-label">Total Duration</label>
-                <input type="text" class="form-control" id="totalDuration" readonly>
-              </div>
+                    <div class="card shadow-sm border-0">
+                      <div class="card-body">
+                        <h5 class="card-title mb-3">Supporting Evidence</h5>
+                        <p class="form-section-description mb-3">Upload any reference file that will be helpful for the appointment.</p>
+                        <div class="upload-box" id="uploadBox">
+                          <div class="upload-text" id="uploadText">Add evidence (JPG, PNG, PDF)</div>
+                          <input type="file" id="imgprofile" name="imgprofile" />
+                          <img id="previewImage" alt="Preview" />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
 
-              <!-- Date & Time -->
-              <div class="mb-3">
-                <label for="bookingDate" class="form-label">Select Date</label>
-                <input type="text" class="form-control" id="bookingDate" name="booking_date" required>
-              </div>
-              <div class="mb-3">
-                <label for="startTime" class="form-label">Select Start Time</label>
-                <select class="form-select" id="startTime" name="start_time" onchange="loadAvailableStaff()" required>
-                  <option value="">Select a time</option>
-                </select>
-              </div>
-
-              <!-- Staff -->
-              <div class="mb-3">
-                <label for="staff" class="form-label">Select Staff</label>
-                <select class="form-select" id="staff" name="staff_id" required>
-                  <option value="">Select a staff member</option>
-                </select>
-              </div>
-
-              <!-- Price Summary -->
-              <div class="summary-card">
-                <h4>Price Summary</h4>
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th>Service</th>
-                      <th>Option</th>
-                      <th>Price (€)</th>
-                    </tr>
-                  </thead>
-                  <tbody id="priceTable"></tbody>
-                  <tfoot>
-                    <tr>
-                      <th colspan="2">Total</th>
-                      <th id="totalPrice">€0.00</th>
-                    </tr>
-                    <tr>
-                      <th colspan="2">Discount</th>
-                      <th id="discountAmount">-€0.00</th>
-                    </tr>
-                    <tr>
-                      <th colspan="2">Final Price</th>
-                      <th id="finalPrice">€0.00</th>
-                    </tr>
-                  </tfoot>
-                </table>
-              </div>
-
-              <!-- Upload evidence -->
-              <div class="col-md-12">
-                <div class="upload-box" id="uploadBox">
-                  <div class="upload-text" id="uploadText">add evidence</div>
-                  <input type="file" id="imgprofile" name="imgprofile" />
-                  <img id="previewImage" alt="Preview" />
+                <div class="col-12 d-flex justify-content-end">
+                  <button type="submit" class="btn btn-primary btn-lg px-4 mt-3 mt-lg-0">Confirm Booking</button>
                 </div>
               </div>
-
-              <!-- Submit -->
-              <button type="submit" class="btn btn-primary mt-3">Confirm Booking</button>
             </form>
 
           </div>
@@ -237,34 +351,38 @@
     function addService(){
       const container = document.getElementById('servicesContainer');
       const newRow = document.createElement('div');
-      newRow.className = 'service-row card p-3 mb-3';
+      newRow.className = 'service-row p-3';
       newRow.innerHTML = `
-        <div class="row">
-          <div class="col-md-6">
+        <div class="row g-3 align-items-end">
+          <div class="col-12 col-md-6">
             <label class="form-label">Select Service</label>
             <select class="form-select service-select" name="services[]" onchange="loadOptions(this)">
               <option value="">Select a service</option>
               <?php foreach ($services as $service) { ?>
-                <option value="<?php echo $service['service_id']; ?>"><?php echo htmlspecialchars($service['service_name']); ?></option>
+                <option value="<?php echo htmlspecialchars($service['service_id']); ?>"><?php echo htmlspecialchars($service['service_name']); ?></option>
               <?php } ?>
             </select>
           </div>
-          <div class="col-md-5">
+          <div class="col-12 col-md-5">
             <label class="form-label">Select Option</label>
             <select class="form-select option-select" name="options[]" onchange="onOptionChange(this)">
               <option value="">Select an option</option>
             </select>
           </div>
-          <div class="col-md-1">
-            <button type="button" class="btn btn-danger mt-4" onclick="removeService(this)">X</button>
+          <div class="col-12 col-md-3 col-lg-2 col-xl-1">
+            <button type="button" class="btn btn-outline-danger btn-sm w-100 remove-service" onclick="removeService(this)">Remove</button>
           </div>
         </div>`;
       container.appendChild(newRow);
     }
 
     function removeService(btn){
+      const container = document.getElementById('servicesContainer');
       const row = btn.closest('.service-row');
       row.remove();
+      if (!container.querySelector('.service-row')) {
+        addService();
+      }
       refreshTotalDuration();
       calculatePrices();
     }
@@ -362,6 +480,7 @@
       let totalPrice = 0;
       let totalDiscount = 0;
       let optionIds = [];
+      let hasRows = false;
 
       const rows = document.querySelectorAll('.service-row');
 
@@ -411,20 +530,25 @@
           totalPrice += price;
           totalDiscount += discountAmount;
 
-          let priceCell = `€${price.toFixed(2)}`;
+          let priceCell = `<span class="fw-semibold">€${price.toFixed(2)}</span>`;
           if (discountAmount > 0){
-            priceCell = `€${finalPrice.toFixed(2)}<div class="text-muted small">ลด -€${discountAmount.toFixed(2)} จาก €${price.toFixed(2)}</div>`;
+            priceCell = `<span class="fw-semibold text-success">€${finalPrice.toFixed(2)}</span><div class="text-muted small">Saved €${discountAmount.toFixed(2)} (was €${price.toFixed(2)})</div>`;
           }
 
           priceTable.insertAdjacentHTML('beforeend', `
             <tr>
               <td>${serviceName}</td>
               <td>${optionText}</td>
-              <td>${priceCell}</td>
+              <td class="text-end">${priceCell}</td>
             </tr>
           `);
+          hasRows = true;
         }
       });
+
+      if (!hasRows) {
+        priceTable.innerHTML = '<tr><td colspan="3" class="text-center text-muted py-4">Select service options to see pricing.</td></tr>';
+      }
 
       document.getElementById('totalPrice').textContent = `€${totalPrice.toFixed(2)}`;
       document.getElementById('discountAmount').textContent = `-€${totalDiscount.toFixed(2)}`;

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -132,7 +132,7 @@
 
             <form id="bookingForm" action="submit_booking.php" method="POST" enctype="multipart/form-data">
               <div class="row g-2">
-                <div class="col-lg-8 d-flex flex-column gap-2">
+                <div class="col-lg-8 d-flex flex-column gap-1">
                   <div class="card shadow-sm border-0 compact-card">
                     <div class="card-body">
                       <h5 class="card-title mb-2">Customer</h5>
@@ -208,7 +208,7 @@
                 </div>
 
                 <div class="col-lg-4">
-                  <div class="d-flex flex-column gap-2 sticky-lg-top" style="top: 5.5rem;">
+                  <div class="d-flex flex-column gap-1 sticky-lg-top" style="top: 5.5rem;">
                     <div class="card shadow-sm summary-card border-0 compact-card">
                       <div class="card-body">
                         <h5 class="card-title mb-2">Price Summary</h5>

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -321,6 +321,13 @@
       return `€${amount.toFixed(2)}`;
     }
 
+    function applyStrikethrough(text){
+      if (!text) {
+        return '';
+      }
+      return `${text.split('').join('\u0336')}\u0336`;
+    }
+
     function buildOptionLabel(durationValue, priceValue, discountInfo){
       const duration = Number.parseInt(durationValue ?? '', 10);
       const hasDuration = !Number.isNaN(duration) && duration > 0;
@@ -337,7 +344,10 @@
           const finalText = formatCurrency(finalPrice);
           const baseText = formatCurrency(basePrice);
           if (finalText && baseText){
-            return durationText ? `${durationText} – ${finalText} (was ${baseText})` : `${finalText} (was ${baseText})`;
+            const baseStruck = applyStrikethrough(baseText);
+            return durationText
+              ? `${durationText} – ${finalText} (${baseStruck})`
+              : `${finalText} (${baseStruck})`;
           }
         }
       }

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -726,11 +726,7 @@
       const finalPriceEl = document.getElementById('finalPrice');
 
       if (totalPriceEl){
-        if (totalDiscount > 0){
-          totalPriceEl.innerHTML = `<span class="text-muted text-decoration-line-through">€${totalBase.toFixed(2)}</span>`;
-        } else {
-          totalPriceEl.textContent = `€${totalBase.toFixed(2)}`;
-        }
+        totalPriceEl.textContent = `€${totalBase.toFixed(2)}`;
       }
 
       if (discountEl){

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -306,6 +306,119 @@
       reader.readAsDataURL(file);
     }
 
+    function parseNumber(value){
+      if (value === undefined || value === null || value === '') {
+        return null;
+      }
+      const num = Number.parseFloat(value);
+      return Number.isNaN(num) ? null : num;
+    }
+
+    function formatCurrency(amount){
+      if (typeof amount !== 'number' || Number.isNaN(amount)) {
+        return '';
+      }
+      return `€${amount.toFixed(2)}`;
+    }
+
+    function buildOptionLabel(durationValue, priceValue, discountInfo){
+      const duration = Number.parseInt(durationValue ?? '', 10);
+      const hasDuration = !Number.isNaN(duration) && duration > 0;
+      const durationText = hasDuration ? `${duration} minutes` : '';
+      const basePrice = parseNumber(priceValue);
+
+      if (discountInfo && basePrice !== null){
+        let finalPrice = parseNumber(discountInfo.final_price);
+        const discountAmount = parseNumber(discountInfo.discount_amount);
+        if (finalPrice === null && discountAmount !== null){
+          finalPrice = Math.max(basePrice - discountAmount, 0);
+        }
+        if (finalPrice !== null && finalPrice < basePrice){
+          const finalText = formatCurrency(finalPrice);
+          const baseText = formatCurrency(basePrice);
+          if (finalText && baseText){
+            return durationText ? `${durationText} – ${finalText} (was ${baseText})` : `${finalText} (was ${baseText})`;
+          }
+        }
+      }
+
+      if (basePrice !== null && basePrice > 0){
+        const baseText = formatCurrency(basePrice);
+        if (baseText){
+          return durationText ? `${durationText} – ${baseText}` : baseText;
+        }
+      }
+
+      return durationText || 'Option';
+    }
+
+    function setOptionDisplay(option, discountInfo){
+      const label = buildOptionLabel(option.dataset.duration, option.dataset.price, discountInfo);
+      if (label){
+        option.textContent = label;
+      }
+
+      const basePrice = parseNumber(option.dataset.price);
+      let resolvedFinal = basePrice;
+      let resolvedDiscount = 0;
+
+      if (discountInfo && basePrice !== null){
+        const fetchedFinal = parseNumber(discountInfo.final_price);
+        const fetchedDiscount = parseNumber(discountInfo.discount_amount);
+        if (fetchedFinal !== null && fetchedFinal < resolvedFinal){
+          resolvedFinal = fetchedFinal;
+        } else if (fetchedDiscount !== null && fetchedDiscount > 0){
+          resolvedFinal = Math.max(basePrice - fetchedDiscount, 0);
+        }
+        if (resolvedFinal !== null && basePrice !== null){
+          resolvedDiscount = Math.max(basePrice - resolvedFinal, 0);
+        }
+      }
+
+      if (resolvedFinal !== null && typeof resolvedFinal === 'number'){
+        option.dataset.finalPrice = resolvedFinal.toFixed(2);
+      } else {
+        option.dataset.finalPrice = '';
+      }
+      option.dataset.discountAmount = resolvedDiscount.toFixed(2);
+    }
+
+    async function applyOptionDiscountLabels(selectEl){
+      if (!selectEl){ return; }
+
+      const optionElements = Array.from(selectEl.options).filter(opt => Number.parseInt(opt.value || '0', 10) > 0);
+      optionElements.forEach(opt => setOptionDisplay(opt, null));
+
+      if (!optionElements.length){
+        calculatePrices();
+        return;
+      }
+
+      const optionIds = optionElements.map(opt => Number.parseInt(opt.value, 10));
+      const { date, time } = getCurrentBookingMoment();
+
+      try {
+        const response = await fetch('get_applicable_promotions.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ option_ids: optionIds, date, time })
+        });
+
+        if (response.ok){
+          const data = await response.json();
+          const discountMap = (data && typeof data === 'object') ? (data.option_discounts || {}) : {};
+          optionElements.forEach(opt => {
+            const optionId = Number.parseInt(opt.value, 10);
+            setOptionDisplay(opt, discountMap[optionId] || null);
+          });
+        }
+      } catch (error) {
+        console.warn('Failed to load option discount details', error);
+      } finally {
+        calculatePrices();
+      }
+    }
+
     // ---------- Select2 for customer ----------
     document.addEventListener('DOMContentLoaded', function () {
       const customerSelect = document.getElementById('customer');
@@ -425,9 +538,9 @@
       const serviceId = serviceSelectEl.value;
 
       optionSelect.innerHTML = '<option value="">Select an option</option>';
+      refreshTotalDuration();
+      calculatePrices();
       if (!serviceId){
-        refreshTotalDuration();
-        calculatePrices();
         return;
       }
 
@@ -439,12 +552,12 @@
             opt.value = o.option_id;
             opt.dataset.duration = o.duration;
             opt.dataset.price = o.price;
-            opt.textContent = `${o.duration} minutes`;
+            opt.textContent = buildOptionLabel(o.duration, o.price, null);
             optionSelect.appendChild(opt);
           });
+          applyOptionDiscountLabels(optionSelect);
           // หลังโหลดตัวเลือก เสนอให้ผู้ใช้เลือกเอง → แค่รีเฟรชสรุปเวลาราคา
           refreshTotalDuration();
-          calculatePrices();
         })
         .catch(() => { /* เงียบไว้ก่อน หรือจะแจ้ง error ก็ได้ */ });
     }
@@ -522,85 +635,69 @@
     }
 
     // ---------- Price summary ----------
-    async function calculatePrices(){
+    function calculatePrices(){
       const priceTable = document.getElementById('priceTable');
+      if (!priceTable){ return; }
+
       priceTable.innerHTML = '';
-      let totalPrice = 0;
-      let totalDiscount = 0;
-      let optionIds = [];
+      let totalBase = 0;
+      let totalFinal = 0;
       let hasRows = false;
 
-      const rows = document.querySelectorAll('.service-row');
-
-      rows.forEach(row => {
-        const oSel = row.querySelector('.option-select');
-        const optionId = parseInt(oSel?.value || '0', 10);
-        if (optionId > 0) {
-          optionIds.push(optionId);
-        }
-      });
-
-      let discountMap = {};
-      const { date: bookingDate, time: bookingTime } = getCurrentBookingMoment();
-
-      if (optionIds.length){
-        try {
-          const response = await fetch('get_applicable_promotions.php', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ option_ids: optionIds, date: bookingDate, time: bookingTime })
-          });
-          if (response.ok){
-            const data = await response.json();
-            if (data && typeof data === 'object'){
-              discountMap = data.option_discounts || {};
-            }
-          }
-        } catch (err) {
-          console.warn('Failed to fetch promotions', err);
-        }
-      }
-
       document.querySelectorAll('.service-row').forEach(row => {
-        const sSel = row.querySelector('.service-select');
-        const oSel = row.querySelector('.option-select');
+        const serviceSelect = row.querySelector('.service-select');
+        const optionSelect = row.querySelector('.option-select');
+        const selectedService = serviceSelect?.options[serviceSelect.selectedIndex];
+        const selectedOption = optionSelect?.options[optionSelect.selectedIndex];
 
-        const serviceName = sSel?.options[sSel.selectedIndex]?.text || '';
-        const optionText  = oSel?.options[oSel.selectedIndex]?.text || '';
-        const price = parseFloat(oSel?.options[oSel.selectedIndex]?.dataset.price || 0);
-        const optionId = parseInt(oSel?.value || '0', 10);
-
-        if (serviceName && optionText && !isNaN(price) && price > 0){
-          const discountInfo = discountMap[optionId] || null;
-          const discountAmount = discountInfo ? parseFloat(discountInfo.discount_amount || 0) : 0;
-          const finalPrice = discountInfo ? parseFloat(discountInfo.final_price || (price - discountAmount)) : price;
-
-          totalPrice += price;
-          totalDiscount += discountAmount;
-
-          let priceCell = `<span class="fw-semibold">€${price.toFixed(2)}</span>`;
-          if (discountAmount > 0){
-            priceCell = `<span class="fw-semibold text-success d-block">€${finalPrice.toFixed(2)}</span><span class="text-muted text-decoration-line-through small d-block">€${price.toFixed(2)}</span>`;
-          }
-
-          priceTable.insertAdjacentHTML('beforeend', `
-            <tr>
-              <td>${serviceName}</td>
-              <td>${optionText}</td>
-              <td class="text-end">${priceCell}</td>
-            </tr>
-          `);
-          hasRows = true;
+        if (!selectedService || !selectedOption){
+          return;
         }
+
+        const serviceName = selectedService.text || '';
+        const optionId = Number.parseInt(selectedOption.value || '0', 10);
+        if (!serviceName || optionId <= 0){
+          return;
+        }
+
+        const basePrice = parseNumber(selectedOption.dataset.price);
+        if (basePrice === null){
+          return;
+        }
+
+        const finalPrice = parseNumber(selectedOption.dataset.finalPrice);
+        const resolvedFinal = finalPrice !== null ? finalPrice : basePrice;
+        const durationValue = Number.parseInt(selectedOption.dataset.duration || '', 10);
+        const optionLabel = !Number.isNaN(durationValue) && durationValue > 0
+          ? `${durationValue} minutes`
+          : (selectedOption.textContent || '');
+
+        totalBase += basePrice;
+        totalFinal += resolvedFinal;
+
+        let priceCell = `<span class="fw-semibold">€${basePrice.toFixed(2)}</span>`;
+        if (resolvedFinal < basePrice){
+          priceCell = `<span class="fw-semibold text-success d-block">€${resolvedFinal.toFixed(2)}</span><span class="text-muted text-decoration-line-through small d-block">€${basePrice.toFixed(2)}</span>`;
+        }
+
+        priceTable.insertAdjacentHTML('beforeend', `
+          <tr>
+            <td>${serviceName}</td>
+            <td>${optionLabel}</td>
+            <td class="text-end">${priceCell}</td>
+          </tr>
+        `);
+        hasRows = true;
       });
 
-      if (!hasRows) {
+      if (!hasRows){
         priceTable.innerHTML = '<tr><td colspan="3" class="text-center text-muted py-4">Select service options to see pricing.</td></tr>';
       }
 
-      document.getElementById('totalPrice').textContent = `€${totalPrice.toFixed(2)}`;
+      const totalDiscount = Math.max(totalBase - totalFinal, 0);
+      document.getElementById('totalPrice').textContent = `€${totalBase.toFixed(2)}`;
       document.getElementById('discountAmount').textContent = `-€${totalDiscount.toFixed(2)}`;
-      document.getElementById('finalPrice').textContent = `€${(totalPrice - totalDiscount).toFixed(2)}`;
+      document.getElementById('finalPrice').textContent = `€${totalFinal.toFixed(2)}`;
     }
   </script>
 </main>

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -26,11 +26,6 @@
       font-weight: 600;
     }
 
-    .form-section-description {
-      font-size: 0.9rem;
-      color: #6c757d;
-    }
-
     .service-row {
       border: 1px dashed #ced4da;
       border-radius: 12px;
@@ -136,11 +131,21 @@
                 <div class="col-lg-8 d-flex flex-column gap-4">
                   <div class="card shadow-sm border-0">
                     <div class="card-body">
+                      <h5 class="card-title mb-3">Customer</h5>
+                      <label for="customer" class="form-label">Select Customer</label>
+                      <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
+                        <option value="">Select a customer</option>
+                        <?php foreach ($customers as $customer) { ?>
+                          <option value="<?php echo htmlspecialchars($customer['customer_id']); ?>"><?php echo htmlspecialchars($customer['customer_id'] . ' - ' . $customer['customer_name']); ?></option>
+                        <?php } ?>
+                      </select>
+                    </div>
+                  </div>
+
+                  <div class="card shadow-sm border-0">
+                    <div class="card-body">
                       <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
-                        <div>
-                          <h5 class="card-title mb-1">Services</h5>
-                          <p class="form-section-description mb-0">Start by selecting the services required for this booking. You can add more than one option.</p>
-                        </div>
+                        <h5 class="card-title mb-0">Services</h5>
                         <button type="button" class="btn btn-outline-primary btn-sm" onclick="addService()">Add Service</button>
                       </div>
 
@@ -170,31 +175,13 @@
                           </div>
                         </div>
                       </div>
-
-                      <div class="alert alert-info mt-4 mb-0 small" role="alert">
-                        Total duration and price summary will update automatically when you choose service options.
-                      </div>
                     </div>
                   </div>
 
                   <div class="card shadow-sm border-0">
                     <div class="card-body">
-                      <div class="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-4">
-                        <div>
-                          <h5 class="card-title mb-1">Customer &amp; Schedule</h5>
-                          <p class="form-section-description mb-0">After selecting services, choose the customer and suitable time slot.</p>
-                        </div>
-                      </div>
+                      <h5 class="card-title mb-3">Schedule</h5>
                       <div class="row g-3">
-                        <div class="col-12">
-                          <label for="customer" class="form-label">Select Customer</label>
-                          <select class="form-select" id="customer" name="customer_id" required style="width: 100%;">
-                            <option value="">Select a customer</option>
-                            <?php foreach ($customers as $customer) { ?>
-                              <option value="<?php echo htmlspecialchars($customer['customer_id']); ?>"><?php echo htmlspecialchars($customer['customer_id'] . ' - ' . $customer['customer_name']); ?></option>
-                            <?php } ?>
-                          </select>
-                        </div>
                         <div class="col-sm-6">
                           <label for="bookingDate" class="form-label">Select Date</label>
                           <input type="text" class="form-control" id="bookingDate" name="booking_date" required disabled>
@@ -261,7 +248,6 @@
                     <div class="card shadow-sm border-0">
                       <div class="card-body">
                         <h5 class="card-title mb-3">Supporting Evidence</h5>
-                        <p class="form-section-description mb-3">Upload any reference file that will be helpful for the appointment.</p>
                         <div class="upload-box" id="uploadBox">
                           <div class="upload-text" id="uploadText">Add evidence (JPG, PNG, PDF)</div>
                           <input type="file" id="imgprofile" name="imgprofile" />

--- a/Admin/booking.php
+++ b/Admin/booking.php
@@ -325,7 +325,7 @@
       if (!text) {
         return '';
       }
-      return `${text.split('').join('\u0336')}\u0336`;
+      return Array.from(text, char => `${char}\u0336`).join('');
     }
 
     function buildOptionLabel(durationValue, priceValue, discountInfo){
@@ -333,6 +333,11 @@
       const hasDuration = !Number.isNaN(duration) && duration > 0;
       const durationText = hasDuration ? `${duration} minutes` : '';
       const basePrice = parseNumber(priceValue);
+      const baseSegments = [];
+
+      if (durationText){
+        baseSegments.push(durationText);
+      }
 
       if (discountInfo && basePrice !== null){
         let finalPrice = parseNumber(discountInfo.final_price);
@@ -344,10 +349,15 @@
           const finalText = formatCurrency(finalPrice);
           const baseText = formatCurrency(basePrice);
           if (finalText && baseText){
+            const segments = [...baseSegments];
             const baseStruck = applyStrikethrough(baseText);
-            return durationText
-              ? `${durationText} – ${finalText} (${baseStruck})`
-              : `${finalText} (${baseStruck})`;
+            if (segments.length){
+              segments.push('–', finalText);
+            } else {
+              segments.push(finalText);
+            }
+            segments.push(baseStruck);
+            return segments.join(' ');
           }
         }
       }
@@ -355,7 +365,13 @@
       if (basePrice !== null && basePrice > 0){
         const baseText = formatCurrency(basePrice);
         if (baseText){
-          return durationText ? `${durationText} – ${baseText}` : baseText;
+          const segments = [...baseSegments];
+          if (segments.length){
+            segments.push('–', baseText);
+          } else {
+            segments.push(baseText);
+          }
+          return segments.join(' ');
         }
       }
 
@@ -705,9 +721,29 @@
       }
 
       const totalDiscount = Math.max(totalBase - totalFinal, 0);
-      document.getElementById('totalPrice').textContent = `€${totalBase.toFixed(2)}`;
-      document.getElementById('discountAmount').textContent = `-€${totalDiscount.toFixed(2)}`;
-      document.getElementById('finalPrice').textContent = `€${totalFinal.toFixed(2)}`;
+      const totalPriceEl = document.getElementById('totalPrice');
+      const discountEl = document.getElementById('discountAmount');
+      const finalPriceEl = document.getElementById('finalPrice');
+
+      if (totalPriceEl){
+        if (totalDiscount > 0){
+          totalPriceEl.innerHTML = `<span class="text-muted text-decoration-line-through">€${totalBase.toFixed(2)}</span>`;
+        } else {
+          totalPriceEl.textContent = `€${totalBase.toFixed(2)}`;
+        }
+      }
+
+      if (discountEl){
+        discountEl.textContent = `-€${totalDiscount.toFixed(2)}`;
+      }
+
+      if (finalPriceEl){
+        if (totalDiscount > 0){
+          finalPriceEl.innerHTML = `<span class="fw-semibold text-success">€${totalFinal.toFixed(2)}</span>`;
+        } else {
+          finalPriceEl.textContent = `€${totalFinal.toFixed(2)}`;
+        }
+      }
     }
   </script>
 </main>


### PR DESCRIPTION
## Summary
- restructure the admin booking form into grouped cards with a responsive two-column layout for details, services, and summary widgets
- refresh the styling of service selectors, summary table, and upload area to improve readability and affordances
- adjust client-side helpers to sanitise option data, keep at least one service row, and present clearer pricing feedback

## Testing
- php -l Admin/booking.php

------
https://chatgpt.com/codex/tasks/task_e_68d38e7d76e4832d89ee125f0a33e765