### PR TITLE
Update income report table and chart

### DIFF
--- a/Admin/report_income.php
+++ b/Admin/report_income.php
@@ -6,8 +6,7 @@
 
 require_once("connect_db.php");
 $confirmedStatus = BOOKING_STATUS_CONFIRMED;
-$pendingStatus   = BOOKING_STATUS_PENDING;
-$cancelledStatus = BOOKING_STATUS_CANCELLED;
+$completedStatus = BOOKING_STATUS_COMPLATE;
 function esc($s){return htmlspecialchars($s??'',ENT_QUOTES,'UTF-8');}
 
 // ----------------------- Year range meta for chart pickers -----------------------
@@ -20,139 +19,219 @@ if ($minYear === 0) { $minYear = (int)date('Y'); $maxYear = (int)date('Y'); }
 if(isset($_GET['action']) && $_GET['action']==='stats'){
   header('Content-Type: application/json; charset=utf-8');
 
-  $period = $_GET['period'] ?? 'month';    // all|month|year
-  $year   = isset($_GET['year'])  ? (int)$_GET['year']  : (int)date('Y');
-  $month  = isset($_GET['month']) ? (int)$_GET['month'] : (int)date('n');
-  $startY = isset($_GET['start_year']) ? (int)$_GET['start_year'] : $minYear;
-  $endY   = isset($_GET['end_year'])   ? (int)$_GET['end_year']   : $maxYear;
+  $view = $_GET['view'] ?? 'years';
+  $view = in_array($view, ['years','months','month_table'], true) ? $view : 'years';
+  $year = isset($_GET['year']) ? (int)$_GET['year'] : (int)date('Y');
+  $month = isset($_GET['month']) ? (int)$_GET['month'] : (int)date('n');
 
-  $staff  = isset($_GET['staff'])  ? (int)$_GET['staff'] : 0;
-  $service= isset($_GET['service'])? (int)$_GET['service'] : 0;
-
-  // ---------- KPI (GLOBAL; confirmed only) ----------
-  $k_net_total = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
-  $k_gross_total = (float)$conn->query("SELECT COALESCE(SUM(total_price),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
-  $k_disc_total = (float)$conn->query("SELECT COALESCE(SUM(total_discount),0) s FROM booking WHERE status={$confirmedStatus}")->fetch_assoc()['s'];
+  // KPI cards (confirmed + completed)
+  $cardWhere = sprintf('status IN (%d,%d)', $confirmedStatus, $completedStatus);
+  $k_net_total = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
+  $k_gross_total = (float)$conn->query("SELECT COALESCE(SUM(total_price),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
+  $k_disc_total = (float)$conn->query("SELECT COALESCE(SUM(total_discount),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
   $ym = date('Y-m');
-  $k_net_mtd = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE status={$confirmedStatus} AND DATE_FORMAT(booking_date,'%Y-%m')='$ym'")->fetch_assoc()['s'];
+  $k_net_mtd = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE $cardWhere AND DATE_FORMAT(booking_date,'%Y-%m')='$ym'")->fetch_assoc()['s'];
 
-  // ---------- Chart bucketing ----------
-  $labels=[]; $groupExpr=""; $dateFilter="1=1"; $axis='';
-  if($period==='month'){
-    $days=cal_days_in_month(CAL_GREGORIAN,$month,$year);
-    for($d=1;$d<=$days;$d++) $labels[]=str_pad((string)$d,2,'0',STR_PAD_LEFT);
-    $groupExpr="DATE_FORMAT(b.booking_date,'%d')";
-    $dateFilter="YEAR(b.booking_date)=$year AND MONTH(b.booking_date)=$month";
-    $axis='วัน';
-  }elseif($period==='year'){
-    $labels=['01','02','03','04','05','06','07','08','09','10','11','12'];
-    $groupExpr="DATE_FORMAT(b.booking_date,'%m')";
-    $dateFilter="YEAR(b.booking_date)=$year";
-    $axis='เดือน';
-  }else{ // all
-    for($y=$startY;$y<=$endY;$y++) $labels[]=(string)$y;
-    $groupExpr="YEAR(b.booking_date)";
-    $dateFilter="YEAR(b.booking_date) BETWEEN $startY AND $endY";
-    $axis='ปี';
-  }
+  if($view === 'years'){
+    $sql = "
+      SELECT YEAR(booking_date) AS y,
+             COALESCE(SUM(final_price),0)      AS net
+      FROM booking
+      WHERE status IN ($confirmedStatus,$completedStatus)
+      GROUP BY YEAR(booking_date)
+      ORDER BY YEAR(booking_date)
+    ";
+    $rs = $conn->query($sql);
+    $keys=[]; $labels=[]; $netSeries=[];
+    while($row=$rs->fetch_assoc()){
+      $y = (int)$row['y'];
+      if($y===0) continue;
+      $keys[]=$y;
+      $labels[]=(string)$y;
+      $netSeries[]=round((float)$row['net'],2);
+    }
 
-  // confirmed revenue only; optional staff/service filters
-  $w=[];
-  $w[]=$dateFilter;
-  $w[]="b.status={$confirmedStatus}";
-  if($staff>0)   $w[]="b.staff_id=".$staff;
-  if($service>0) $w[]="EXISTS (SELECT 1 FROM booking_seviceop bs JOIN service_option so ON bs.option_id=so.option_id WHERE bs.booking_id=b.booking_id AND so.service_id=".$service.")";
-  $where=implode(" AND ",$w);
-
-  $sql="
-    SELECT $groupExpr AS b,
-           COALESCE(SUM(b.total_price),0)      AS gross,
-           COALESCE(SUM(b.total_discount),0)   AS discount,
-           COALESCE(SUM(b.final_price),0)      AS net,
-           COUNT(*)                            AS n
-    FROM booking b
-    WHERE $where
-    GROUP BY b
-    ORDER BY b
-  ";
-  $rs=$conn->query($sql);
-  $mapG=[]; $mapD=[]; $mapN=[]; $mapC=[];
-  while($row=$rs->fetch_assoc()){
-    $k=(string)$row['b'];
-    $mapG[$k]=(float)$row['gross'];
-    $mapD[$k]=(float)$row['discount'];
-    $mapN[$k]=(float)$row['net'];
-    $mapC[$k]=(int)$row['n'];
-  }
-  $seriesGross=[]; $seriesDisc=[]; $seriesNet=[]; $seriesCnt=[];
-  foreach($labels as $b){
-    $seriesGross[] = round($mapG[$b] ?? 0, 2);
-    $seriesDisc[]  = round($mapD[$b] ?? 0, 2);
-    $seriesNet[]   = round($mapN[$b] ?? 0, 2);
-    $seriesCnt[]   = (int)($mapC[$b] ?? 0);
-  }
-
-  echo json_encode([
-    'cards'=>[
-      'net_total'   => $k_net_total,
-      'net_mtd'     => $k_net_mtd,
-      'gross_total' => $k_gross_total,
-      'disc_total'  => $k_disc_total
-    ],
-    'chart'=>[
-      'labels'=>$labels, 'axis'=>$axis,
-      'series'=>[
-        'gross'=>$seriesGross, 'discount'=>$seriesDisc, 'net'=>$seriesNet, 'count'=>$seriesCnt
+    echo json_encode([
+      'type'=>'years',
+      'keys'=>$keys,
+      'labels'=>$labels,
+      'series'=>['net'=>$netSeries],
+      'cards'=>[
+        'net_total'=>$k_net_total,
+        'net_mtd'=>$k_net_mtd,
+        'gross_total'=>$k_gross_total,
+        'disc_total'=>$k_disc_total
       ]
-    ]
-  ]);
-  exit;
+    ]);
+    exit;
+  }
+
+  if($view === 'months'){
+    if($year < $minYear || $year > $maxYear){ $year = (int)date('Y'); }
+    $sql = "
+      SELECT MONTH(booking_date) AS m,
+             COALESCE(SUM(final_price),0) AS net
+      FROM booking
+      WHERE status IN ($confirmedStatus,$completedStatus) AND YEAR(booking_date)=$year
+      GROUP BY MONTH(booking_date)
+      ORDER BY MONTH(booking_date)
+    ";
+    $rs = $conn->query($sql);
+    $map=[];
+    while($row=$rs->fetch_assoc()){
+      $map[(int)$row['m']] = round((float)$row['net'],2);
+    }
+    $keys=[]; $labels=[]; $netSeries=[];
+    for($m=1;$m<=12;$m++){
+      $keys[]=$m;
+      $labels[]=str_pad((string)$m,2,'0',STR_PAD_LEFT);
+      $netSeries[] = $map[$m] ?? 0;
+    }
+
+    echo json_encode([
+      'type'=>'months',
+      'year'=>$year,
+      'keys'=>$keys,
+      'labels'=>$labels,
+      'series'=>['net'=>$netSeries],
+      'cards'=>[
+        'net_total'=>$k_net_total,
+        'net_mtd'=>$k_net_mtd,
+        'gross_total'=>$k_gross_total,
+        'disc_total'=>$k_disc_total
+      ]
+    ]);
+    exit;
+  }
+
+  if($view === 'month_table'){
+    if($month < 1 || $month > 12) $month = (int)date('n');
+    $stmt = $conn->prepare("SELECT
+        b.booking_id,
+        b.b_created_at,
+        b.booking_date,
+        b.time_start,
+        b.time_end,
+        b.total_price,
+        b.total_discount,
+        b.final_price,
+        b.status,
+        c.customer_name,
+        s.staff_name,
+        COALESCE(GROUP_CONCAT(DISTINCT sv.service_name ORDER BY sv.service_name SEPARATOR ', '), '') AS services
+      FROM booking b
+      LEFT JOIN customer c ON b.customer_id=c.customer_id
+      LEFT JOIN staff s ON b.staff_id=s.staff_id
+      LEFT JOIN booking_seviceop bs ON bs.booking_id=b.booking_id
+      LEFT JOIN service_option so ON bs.option_id=so.option_id
+      LEFT JOIN service sv ON so.service_id=sv.service_id
+      WHERE b.status IN ($confirmedStatus,$completedStatus)
+        AND YEAR(b.booking_date)=?
+        AND MONTH(b.booking_date)=?
+      GROUP BY b.booking_id
+      ORDER BY b.booking_date ASC, b.time_start ASC");
+    $stmt->bind_param('ii', $year, $month);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    $rows=[];
+    $gross=0; $disc=0; $net=0;
+    while($row=$rs->fetch_assoc()){
+      $bookedAt = $row['b_created_at'] ? date('Y-m-d H:i', strtotime($row['b_created_at'])) : '-';
+      $serviceAt = $row['booking_date'] ? $row['booking_date'] : '';
+      if($serviceAt !== ''){
+        $start = $row['time_start'] ? substr($row['time_start'],0,5) : '';
+        $end = $row['time_end'] ? substr($row['time_end'],0,5) : '';
+        $serviceAt = trim($serviceAt.' '.($start!==''?$start:'').($end!==''?"-$end":''));
+      }else{
+        $serviceAt = '-';
+      }
+      $gross += (float)$row['total_price'];
+      $disc  += (float)$row['total_discount'];
+      $net   += (float)$row['final_price'];
+      $statusCode = booking_status_code($row['status']);
+      $rows[] = [
+        'booking_id' => (int)$row['booking_id'],
+        'booked_at' => esc($bookedAt),
+        'service_at' => esc($serviceAt ?: '-'),
+        'customer' => esc($row['customer_name'] ?: '-'),
+        'services' => esc($row['services'] ?: '-'),
+        'staff' => esc($row['staff_name'] ?: '-'),
+        'gross' => round((float)$row['total_price'],2),
+        'discount' => round((float)$row['total_discount'],2),
+        'net' => round((float)$row['final_price'],2),
+        'status_label' => esc(booking_status_label($statusCode)),
+        'status_badge' => esc(booking_status_badge_class($statusCode))
+      ];
+    }
+    $stmt->close();
+
+    echo json_encode([
+      'type'=>'month_table',
+      'year'=>$year,
+      'month'=>$month,
+      'label'=>date('F', mktime(0,0,0,$month,1,$year)),
+      'rows'=>$rows,
+      'totals'=>[
+        'gross'=>round($gross,2),
+        'discount'=>round($disc,2),
+        'net'=>round($net,2)
+      ],
+      'cards'=>[
+        'net_total'=>$k_net_total,
+        'net_mtd'=>$k_net_mtd,
+        'gross_total'=>$k_gross_total,
+        'disc_total'=>$k_disc_total
+      ]
+    ]);
+    exit;
+  }
 }
 
 // ======================= TABLE: filters + sort + pagination =======================
-$search = trim($_GET['q'] ?? '');
-$statusParam = $_GET['status'] ?? (string)$confirmedStatus; // default confirmed for income
-$statusCode = $statusParam === 'all' ? null : booking_status_code($statusParam);
-$statusValue = $statusCode === null ? 'all' : (string)$statusCode;
-$staffF = isset($_GET['staff']) ? (int)$_GET['staff'] : 0;
+$statusParam = $_GET['status'] ?? 'all';
+$statusFilter = null;
+if($statusParam !== 'all'){
+  $parsedStatus = booking_status_code($statusParam);
+  if(in_array($parsedStatus, [$confirmedStatus, $completedStatus], true)){
+    $statusFilter = $parsedStatus;
+  }
+}
+$statusValue = $statusFilter === null ? 'all' : (string)$statusFilter;
 $serviceF = isset($_GET['service']) ? (int)$_GET['service'] : 0;
-$startDate = $_GET['start_date'] ?? '';
-$endDate   = $_GET['end_date']   ?? '';
-$sort   = $_GET['sort'] ?? 'date';
+$sort   = $_GET['sort'] ?? 'booked_at';
 $dir    = strtoupper($_GET['dir'] ?? 'DESC'); $dir=$dir==='ASC'?'ASC':'DESC';
 
+$rangeType = $_GET['range_type'] ?? 'all';
+if(!in_array($rangeType, ['all','day','month','year'], true)) $rangeType = 'all';
+$rangeDay = $_GET['range_day'] ?? '';
+$rangeMonth = isset($_GET['range_month']) ? (int)$_GET['range_month'] : (int)date('n');
+if($rangeMonth < 1 || $rangeMonth > 12) $rangeMonth = (int)date('n');
+$rangeYear = isset($_GET['range_year']) ? (int)$_GET['range_year'] : (int)date('Y');
+
 $sortMap=[
-  'date'    => "b.booking_date $dir, b.time_start $dir",
-  'customer'=> "c.customer_name $dir",
-  'staff'   => "s.staff_name $dir",
-  'gross'   => "b.total_price $dir",
-  'disc'    => "b.total_discount $dir",
-  'net'     => "b.final_price $dir",
-  'status'  => "b.status $dir"
+  'booked_at'  => "b.b_created_at $dir",
+  'service_at' => "b.booking_date $dir, b.time_start $dir"
 ];
-$orderBy = $sortMap[$sort] ?? $sortMap['date'];
+$orderBy = $sortMap[$sort] ?? $sortMap['booked_at'];
 
 // WHERE
-$where = ["1=1"]; $types=""; $params=[];
-if($search!==''){
-  $where[]="(c.customer_name LIKE ? OR c.gmail LIKE ? OR s.staff_name LIKE ?)";
-  $kw="%$search%"; $params[]=$kw; $params[]=$kw; $params[]=$kw; $types.="sss";
-}
-if($statusCode !== null){
-  $where[]="b.status=?"; $params[]=$statusCode; $types.="i";
-}
-if($staffF>0){
-  $where[]="b.staff_id=?"; $params[]=$staffF; $types.="i";
-}
-if($startDate!==''){
-  $where[]="b.booking_date>=?"; $params[]=$startDate; $types.="s";
-}
-if($endDate!==''){
-  $where[]="b.booking_date<=?"; $params[]=$endDate; $types.="s";
+$where = ["b.status IN ($confirmedStatus,$completedStatus)"]; $types=""; $params=[];
+if($statusFilter !== null){
+  $where[]="b.status=?"; $params[]=$statusFilter; $types.="i";
 }
 if($serviceF>0){
   $where[]="EXISTS (SELECT 1 FROM booking_seviceop bs JOIN service_option so ON bs.option_id=so.option_id WHERE bs.booking_id=b.booking_id AND so.service_id=?)";
   $params[]=$serviceF; $types.="i";
+}
+if($rangeType==='day'){
+  if(preg_match('/^\d{4}-\d{2}-\d{2}$/',$rangeDay)){
+    $where[]="b.booking_date=?"; $params[]=$rangeDay; $types.='s';
+  }
+}elseif($rangeType==='month'){
+  $where[]="YEAR(b.booking_date)=?"; $params[]=$rangeYear; $types.='i';
+  $where[]="MONTH(b.booking_date)=?"; $params[]=$rangeMonth; $types.='i';
+}elseif($rangeType==='year'){
+  $where[]="YEAR(b.booking_date)=?"; $params[]=$rangeYear; $types.='i';
 }
 $whereSql = implode(" AND ",$where);
 
@@ -188,10 +267,19 @@ $stmt->execute(); $trow=$stmt->get_result()->fetch_assoc(); $stmt->close();
 
 // List
 $sqlList="
-  SELECT 
-    b.booking_id, b.booking_date, b.time_start, b.time_end,
-    b.total_price, b.total_discount, b.final_price, b.status,
-    c.customer_name, c.gmail, s.staff_name,
+  SELECT
+    b.booking_id,
+    b.b_created_at,
+    b.booking_date,
+    b.time_start,
+    b.time_end,
+    b.total_price,
+    b.total_discount,
+    b.final_price,
+    b.status,
+    c.customer_name,
+    c.gmail,
+    s.staff_name,
     GROUP_CONCAT(DISTINCT sv.service_name ORDER BY sv.service_name SEPARATOR ', ') AS services
   FROM booking b
   LEFT JOIN customer c ON b.customer_id=c.customer_id
@@ -210,7 +298,6 @@ $stmt->execute(); $rs=$stmt->get_result();
 $rows=[]; while($r=$rs->fetch_assoc()) $rows[]=$r; $stmt->close();
 
 // Dropdowns
-$staffOps   = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staff_name");
 $serviceOps = $conn->query("SELECT service_id, service_name FROM service ORDER BY service_name");
 
 $baseQuery = $_GET;
@@ -259,30 +346,11 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <form class="row g-2 align-items-end" method="get">
           <input type="hidden" name="tab" value="table">
           <div class="col-md-auto">
-            <label class="form-label small-label">ค้นหา</label>
-            <input type="text" class="form-control" name="q" value="<?=esc($search)?>" placeholder="ลูกค้า/อีเมล/พนักงาน">
-          </div>
-          <div class="col-md-auto">
             <label class="form-label small-label">สถานะ</label>
             <select class="form-select" name="status">
-              <?php
-                $statusOptions = ['all' => 'ทั้งหมด'];
-                foreach (booking_status_options() as $code => $label) {
-                  $statusOptions[(string)$code] = $label;
-                }
-                foreach ($statusOptions as $key => $label):
-              ?>
-                <option value="<?=$key?>" <?= $statusValue === $key ? 'selected' : '' ?>><?=$label?></option>
-              <?php endforeach; ?>
-            </select>
-          </div>
-          <div class="col-md-auto">
-            <label class="form-label small-label">พนักงาน</label>
-            <select class="form-select" name="staff">
-              <option value="0">ทั้งหมด</option>
-              <?php while($s=$staffOps->fetch_assoc()): ?>
-                <option value="<?=$s['staff_id']?>" <?= $staffF==$s['staff_id']?'selected':'' ?>><?=esc($s['staff_name'])?></option>
-              <?php endwhile; ?>
+              <option value="all" <?= $statusValue==='all'?'selected':'' ?>>ทั้งหมด</option>
+              <option value="<?=$confirmedStatus?>" <?= $statusValue===(string)$confirmedStatus?'selected':'' ?>>Confirmed</option>
+              <option value="<?=$completedStatus?>" <?= $statusValue===(string)$completedStatus?'selected':'' ?>>Completed</option>
             </select>
           </div>
           <div class="col-md-auto">
@@ -295,27 +363,43 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">วันที่</label>
+            <label class="form-label small-label">ช่วงเวลา</label>
+            <select class="form-select" name="range_type" id="rangeType">
+              <option value="all" <?= $rangeType==='all'?'selected':'' ?>>ทั้งหมด</option>
+              <option value="day" <?= $rangeType==='day'?'selected':'' ?>>รายวัน</option>
+              <option value="month" <?= $rangeType==='month'?'selected':'' ?>>รายเดือน</option>
+              <option value="year" <?= $rangeType==='year'?'selected':'' ?>>รายปี</option>
+            </select>
+          </div>
+          <div class="col-md-auto range-extra <?= $rangeType==='day'?'':'d-none' ?>" data-range="day">
+            <label class="form-label small-label">เลือกวันที่</label>
+            <input type="date" class="form-control" name="range_day" value="<?=esc($rangeDay)?>" <?= $rangeType==='day'?'':'disabled' ?>>
+          </div>
+          <div class="col-md-auto range-extra <?= $rangeType==='month'?'':'d-none' ?>" data-range="month">
+            <label class="form-label small-label">เลือกเดือน/ปี</label>
             <div class="d-flex gap-2">
-              <input type="date" class="form-control" name="start_date" value="<?=esc($startDate)?>">
-              <input type="date" class="form-control" name="end_date"   value="<?=esc($endDate)?>">
+              <select class="form-select" name="range_month" <?= $rangeType==='month'?'':'disabled' ?>>
+                <?php for($m=1;$m<=12;$m++): ?>
+                  <option value="<?=$m?>" <?= $rangeMonth==$m?'selected':'' ?>><?=$m?></option>
+                <?php endfor; ?>
+              </select>
+              <input type="number" class="form-control" name="range_year" value="<?=esc($rangeYear)?>" min="2000" max="2100" <?= $rangeType==='month'?'':'disabled' ?>>
             </div>
+          </div>
+          <div class="col-md-auto range-extra <?= $rangeType==='year'?'':'d-none' ?>" data-range="year">
+            <label class="form-label small-label">เลือกปี</label>
+            <input type="number" class="form-control" name="range_year" value="<?=esc($rangeYear)?>" min="2000" max="2100" <?= $rangeType==='year'?'':'disabled' ?>>
           </div>
           <div class="col-md-auto">
             <label class="form-label small-label">Sort by</label>
             <div class="input-group">
               <select class="form-select" name="sort">
-                <option value="date"     <?= $sort==='date'?'selected':'' ?>>วันที่</option>
-                <option value="customer" <?= $sort==='customer'?'selected':'' ?>>ลูกค้า</option>
-                <option value="staff"    <?= $sort==='staff'?'selected':'' ?>>พนักงาน</option>
-                <option value="gross"    <?= $sort==='gross'?'selected':'' ?>>Gross</option>
-                <option value="disc"     <?= $sort==='disc'?'selected':'' ?>>Discount</option>
-                <option value="net"      <?= $sort==='net'?'selected':'' ?>>Net</option>
-                <option value="status"   <?= $sort==='status'?'selected':'' ?>>สถานะ</option>
+                <option value="booked_at"  <?= $sort==='booked_at'?'selected':'' ?>>วันเวลาที่ทำการจอง</option>
+                <option value="service_at" <?= $sort==='service_at'?'selected':'' ?>>วันเวลาที่เข้าใช้บริการ</option>
               </select>
               <select class="form-select" name="dir">
-                <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>ASC</option>
-                <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>DESC</option>
+                <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>เก่า → ใหม่</option>
+                <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>ใหม่ → เก่า</option>
               </select>
             </div>
           </div>
@@ -332,42 +416,47 @@ $pageUrl = function(int $target) use ($baseQuery): string {
           <table class="table table-striped table-hover align-middle">
             <thead class="table-light">
               <tr>
-                <th>Booking ID</th>
+                <th>ID</th>
+                <th>วันเวลาที่ทำการจอง</th>
+                <th>วันเวลาที่เข้าใช้บริการ</th>
                 <th>Customer</th>
-                <th>Date</th>
-                <th>Time</th>
-                <th>Services</th>
+                <th>Service</th>
                 <th>Staff</th>
-                <th class="text-end">Gross</th>
-                <th class="text-end">Discount</th>
-                <th class="text-end">Net</th>
+                <th class="text-end">ราคาก่อนหักส่วนลด</th>
+                <th class="text-end">ส่วนลด</th>
+                <th class="text-end">ราคาหลังหักส่วนลด</th>
                 <th>Status</th>
-                <th>Action</th>
               </tr>
             </thead>
             <tbody>
               <?php if(empty($rows)): ?>
-                <tr><td colspan="11" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="10" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
               <?php else: foreach($rows as $r): ?>
                 <tr>
+                  <?php
+                    $bookedAt = $r['b_created_at'] ? date('Y-m-d H:i', strtotime($r['b_created_at'])) : '-';
+                    $serviceDate = $r['booking_date'] ?: '';
+                    $startTime = $r['time_start'] ? substr($r['time_start'],0,5) : '';
+                    $endTime = $r['time_end'] ? substr($r['time_end'],0,5) : '';
+                    $serviceAt = '-';
+                    if($serviceDate !== ''){
+                      $timeRange = trim($startTime.($endTime!==''?"-$endTime":''));
+                      $serviceAt = trim($serviceDate.' '.$timeRange);
+                    }
+                    $statusCode = booking_status_code($r['status']);
+                    $badgeClass = booking_status_badge_class($statusCode);
+                    $statusLabel = booking_status_label($statusCode);
+                  ?>
                   <td><?=esc($r['booking_id'])?></td>
-                  <td><?=esc($r['customer_name']?:'N/A')?><br><small class="text-muted"><?=esc($r['gmail']?:'-')?></small></td>
-                  <td><?=esc($r['booking_date'])?></td>
-                  <td><?=esc(substr($r['time_start'],0,5))?>–<?=esc(substr($r['time_end'],0,5))?></td>
-                  <td><?=esc($r['services']?:'N/A')?></td>
-                  <td><?=esc($r['staff_name']?:'N/A')?></td>
+                  <td><?=esc($bookedAt)?></td>
+                  <td><?=esc($serviceAt)?></td>
+                  <td><?=esc($r['customer_name']?:'N/A')?><?php if(!empty($r['gmail'])): ?><br><small class="text-muted"><?=esc($r['gmail'])?></small><?php endif; ?></td>
+                  <td><?=esc($r['services']?:'-')?></td>
+                  <td><?=esc($r['staff_name']?:'-')?></td>
                   <td class="text-end"><?=number_format((float)$r['total_price'],2)?></td>
                   <td class="text-end text-danger">-<?=number_format((float)$r['total_discount'],2)?></td>
                   <td class="text-end fw-bold text-success"><?=number_format((float)$r['final_price'],2)?></td>
-                  <td>
-                    <?php $stCode = booking_status_code($r['status']); $badgeClass = booking_status_badge_class($stCode); $label = booking_status_label($stCode); ?>
-                    <span class="badge <?=$badgeClass?>"><?=esc($label)?></span>
-                  </td>
-                  <td>
-                    <div class="btn-group">
-                      <a href="booking_detail.php?id=<?= (int)$r['booking_id'] ?>" class="btn btn-sm btn-outline-primary" title="View Details"><i class="bi bi-eye"></i></a>
-                    </div>
-                  </td>
+                  <td><span class="badge <?=$badgeClass?>"><?=esc($statusLabel)?></span></td>
                 </tr>
               <?php endforeach; endif; ?>
             </tbody>
@@ -378,7 +467,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                 <th class="text-end"><?=number_format((float)$trow['gross_sum'],2)?></th>
                 <th class="text-end text-danger">-<?=number_format((float)$trow['disc_sum'],2)?></th>
                 <th class="text-end text-success"><?=number_format((float)$trow['net_sum'],2)?></th>
-                <th colspan="2"></th>
+                <th></th>
               </tr>
             </tfoot>
             <?php endif; ?>
@@ -410,82 +499,11 @@ $pageUrl = function(int $target) use ($baseQuery): string {
     <div class="tab-pane fade" id="t-chart">
       <div class="card mt-3"><div class="card-body">
 
-        <!-- Chart filters -->
-        <div class="row g-3 align-items-end">
-          <div class="col-md-auto">
-            <label class="form-label small-label">ช่วงเวลา</label>
-            <div class="btn-group" role="group">
-              <input type="radio" class="btn-check" name="period" id="p_all" value="all">
-              <label class="btn btn-outline-primary" for="p_all">All</label>
-              <input type="radio" class="btn-check" name="period" id="p_month" value="month" checked>
-              <label class="btn btn-outline-primary" for="p_month">Month</label>
-              <input type="radio" class="btn-check" name="period" id="p_year" value="year">
-              <label class="btn btn-outline-primary" for="p_year">Year</label>
-            </div>
-          </div>
-          <div class="col-md-auto">
-            <label class="form-label small-label">พนักงาน</label>
-            <select id="chart_staff" class="form-select">
-              <option value="0">ทั้งหมด</option>
-              <?php $staffOps2 = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staff_name"); while($s=$staffOps2->fetch_assoc()): ?>
-                <option value="<?=$s['staff_id']?>"><?=esc($s['staff_name'])?></option>
-              <?php endwhile; ?>
-            </select>
-          </div>
-          <div class="col-md-auto">
-            <label class="form-label small-label">บริการ</label>
-            <select id="chart_service" class="form-select">
-              <option value="0">ทั้งหมด</option>
-              <?php $serviceOps2 = $conn->query("SELECT service_id, service_name FROM service ORDER BY service_name"); while($sv=$serviceOps2->fetch_assoc()): ?>
-                <option value="<?=$sv['service_id']?>"><?=esc($sv['service_name'])?></option>
-              <?php endwhile; ?>
-            </select>
-          </div>
-
-          <!-- Period-specific controls -->
-          <div class="col-md-auto" id="ctl-month">
-            <label class="form-label small-label">เดือน/ปี</label>
-            <div class="d-flex gap-2">
-              <select id="month" class="form-select">
-                <?php for($m=1;$m<=12;$m++): ?>
-                  <option value="<?=$m?>" <?= $m==(int)date('n')?'selected':'' ?>><?=$m?></option>
-                <?php endfor; ?>
-              </select>
-              <select id="year_m" class="form-select">
-                <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
-                  <option value="<?=$y?>" <?= $y==(int)date('Y')?'selected':'' ?>><?=$y?></option>
-                <?php endfor; ?>
-              </select>
-            </div>
-          </div>
-          <div class="col-md-auto d-none" id="ctl-year">
-            <label class="form-label small-label">ปี</label>
-            <select id="year_y" class="form-select">
-              <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
-                <option value="<?=$y?>" <?= $y==(int)date('Y')?'selected':'' ?>><?=$y?></option>
-              <?php endfor; ?>
-            </select>
-          </div>
-          <div class="col-md-auto d-none" id="ctl-all">
-            <label class="form-label small-label">ช่วงปี</label>
-            <div class="d-flex gap-2">
-              <select id="start_year" class="form-select">
-                <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
-                  <option value="<?=$y?>" <?= $y==$minYear?'selected':'' ?>><?=$y?></option>
-                <?php endfor; ?>
-              </select>
-              <select id="end_year" class="form-select">
-                <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
-                  <option value="<?=$y?>" <?= $y==$maxYear?'selected':'' ?>><?=$y?></option>
-                <?php endfor; ?>
-              </select>
-            </div>
-          </div>
-
-          <div class="col-md-auto">
-            <button id="applyChart" class="btn btn-primary"><i class="bi bi-funnel"></i> ใช้ตัวกรอง</button>
-          </div>
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+          <h5 class="mb-0" id="chartTitle">รายได้รายปี</h5>
+          <button type="button" class="btn btn-outline-secondary btn-sm d-none" id="chartBack"><i class="bi bi-arrow-left"></i> ย้อนกลับ</button>
         </div>
+        <div class="text-muted mt-1">ข้อมูลเฉพาะการจองที่ยืนยันแล้วและเสร็จสิ้น</div>
 
         <!-- KPI (GLOBAL) -->
         <div class="row mt-3">
@@ -512,7 +530,9 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <div class="mt-3" style="min-height:380px">
           <canvas id="incomeChart" height="120"></canvas>
         </div>
-        <div class="text-muted mt-2">* แท่ง: Gross / Discount / Net (เฉพาะ Confirmed) &nbsp;—&nbsp; คลิก legend เพื่อเปิด–ปิดชุดข้อมูล</div>
+        <div class="text-muted mt-2">คลิกแท่งปีเพื่อดูรายเดือน และคลิกแท่งเดือนเพื่อดูตารางของเดือนนั้น</div>
+
+        <div id="monthTable" class="mt-4"></div>
 
       </div></div>
     </div>
@@ -522,61 +542,175 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-function updateCtl(){
-  const p=document.querySelector('input[name=period]:checked')?.value||'month';
-  document.getElementById('ctl-month').classList.toggle('d-none',p!=='month');
-  document.getElementById('ctl-year').classList.toggle('d-none',p!=='year');
-  document.getElementById('ctl-all').classList.toggle('d-none',p!=='all');
+const rangeSelect=document.getElementById('rangeType');
+function updateRangeControls(){
+  const value=rangeSelect?.value||'all';
+  document.querySelectorAll('.range-extra').forEach(el=>{
+    const target=el.getAttribute('data-range');
+    const active=value===target;
+    el.classList.toggle('d-none',!active);
+    el.querySelectorAll('input,select').forEach(ctrl=>{ ctrl.disabled=!active; });
+  });
 }
-['p_all','p_month','p_year'].forEach(id=>document.getElementById(id).addEventListener('change',updateCtl));
-updateCtl();
+if(rangeSelect){
+  rangeSelect.addEventListener('change',updateRangeControls);
+  updateRangeControls();
+}
 
+const chartCanvas=document.getElementById('incomeChart');
+const chartCtx=chartCanvas?chartCanvas.getContext('2d'):null;
+const chartTitleEl=document.getElementById('chartTitle');
+const chartBackBtn=document.getElementById('chartBack');
+const monthTableWrap=document.getElementById('monthTable');
 let chart;
-async function loadStats(){
-  const p=document.querySelector('input[name=period]:checked')?.value||'month';
-  const url=new URL(location.href); url.search=''; url.searchParams.set('action','stats'); url.searchParams.set('period',p);
-  url.searchParams.set('staff',document.getElementById('chart_staff').value);
-  url.searchParams.set('service',document.getElementById('chart_service').value);
-  if(p==='month'){ url.searchParams.set('year',document.getElementById('year_m').value); url.searchParams.set('month',document.getElementById('month').value); }
-  else if(p==='year'){ url.searchParams.set('year',document.getElementById('year_y').value); }
-  else { url.searchParams.set('start_year',document.getElementById('start_year').value); url.searchParams.set('end_year',document.getElementById('end_year').value); }
+let currentYear=null;
 
-  const res=await fetch(url.toString(),{cache:'no-store'});
-  const data=await res.json();
+const nf=(v)=>Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
 
-  // KPIs
-  const nf=(v)=>Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
-  document.getElementById('k_net_total').textContent  = nf(data.cards.net_total);
-  document.getElementById('k_net_mtd').textContent    = nf(data.cards.net_mtd);
-  document.getElementById('k_gross_total').textContent= nf(data.cards.gross_total);
-  document.getElementById('k_disc_total').textContent = nf(data.cards.disc_total);
-
-  // Chart
-  const labels=data.chart.labels, axis=data.chart.axis;
-  const sG=data.chart.series.gross, sD=data.chart.series.discount, sN=data.chart.series.net;
-
-  if(chart) chart.destroy();
-  const ctx=document.getElementById('incomeChart').getContext('2d');
-  chart=new Chart(ctx,{
-    type:'bar',
-    data:{
-      labels,
-      datasets:[
-        {label:'Gross',    data:sG, borderWidth:1},
-        {label:'Discount', data:sD, borderWidth:1},
-        {label:'Net',      data:sN, borderWidth:1}
-      ]
-    },
-    options:{
-      responsive:true, maintainAspectRatio:false,
-      scales:{ x:{ title:{display:true,text:axis} }, y:{ beginAtZero:true } },
-      plugins:{ legend:{display:true}, tooltip:{mode:'index', intersect:false} }
-    }
+function updateCards(cards){
+  if(!cards) return;
+  const mapping={
+    k_net_total:cards.net_total,
+    k_net_mtd:cards.net_mtd,
+    k_gross_total:cards.gross_total,
+    k_disc_total:cards.disc_total
+  };
+  Object.entries(mapping).forEach(([id,val])=>{
+    const el=document.getElementById(id);
+    if(el) el.textContent=nf(val);
   });
 }
 
-document.getElementById('applyChart').addEventListener('click',loadStats);
-document.getElementById('chart-tab')?.addEventListener('shown.bs.tab',()=>loadStats());
+async function loadChart(view='years', year=null){
+  if(!chartCtx) return;
+  try{
+    const url=new URL(location.href);
+    url.search='';
+    url.searchParams.set('action','stats');
+    url.searchParams.set('view',view);
+    if(view==='months'){
+      const targetYear=year ?? currentYear ?? new Date().getFullYear();
+      currentYear=targetYear;
+      url.searchParams.set('year',targetYear);
+    }else{
+      currentYear=null;
+    }
+    const res=await fetch(url.toString(),{cache:'no-store'});
+    const data=await res.json();
+    updateCards(data.cards || null);
+    renderChart(data);
+    if(view==='years' && monthTableWrap){
+      monthTableWrap.innerHTML='';
+    }
+  }catch(err){
+    console.error(err);
+  }
+}
+
+function renderChart(data){
+  if(!chartCtx) return;
+  const labels=data.labels || [];
+  const netSeries=data.series?.net || [];
+  const keys=data.keys || [];
+  if(chart) chart.destroy();
+  chart=new Chart(chartCtx,{
+    type:'bar',
+    data:{
+      labels,
+      datasets:[{
+        label:'รายได้หลังหักส่วนลด',
+        data:netSeries,
+        backgroundColor:'rgba(13,110,253,0.7)',
+        borderColor:'rgba(13,110,253,1)',
+        borderWidth:1,
+        borderRadius:6
+      }]
+    },
+    options:{
+      responsive:true,
+      maintainAspectRatio:false,
+      scales:{
+        y:{
+          beginAtZero:true,
+          ticks:{ callback:value=>nf(value) }
+        }
+      },
+      plugins:{
+        legend:{display:false},
+        tooltip:{ callbacks:{ label:ctx=>`รายได้: ฿${nf(ctx.parsed.y)}` } }
+      },
+      onClick:(evt,elements)=>{
+        if(!elements.length) return;
+        const idx=elements[0].index;
+        const key=keys[idx];
+        if(data.type==='years' && key){
+          if(monthTableWrap) monthTableWrap.innerHTML='';
+          loadChart('months',key);
+        }else if(data.type==='months' && key){
+          loadMonthTable(data.year,key);
+        }
+      }
+    }
+  });
+
+  if(chartTitleEl){
+    if(data.type==='months'){
+      chartTitleEl.textContent=`รายได้ปี ${data.year}`;
+      chartBackBtn?.classList.remove('d-none');
+    }else{
+      chartTitleEl.textContent='รายได้รายปี';
+      chartBackBtn?.classList.add('d-none');
+    }
+  }
+}
+
+async function loadMonthTable(year, month){
+  if(!monthTableWrap) return;
+  monthTableWrap.innerHTML='<div class="text-muted">กำลังโหลด...</div>';
+  try{
+    const url=new URL(location.href);
+    url.search='';
+    url.searchParams.set('action','stats');
+    url.searchParams.set('view','month_table');
+    url.searchParams.set('year',year);
+    url.searchParams.set('month',month);
+    const res=await fetch(url.toString(),{cache:'no-store'});
+    const data=await res.json();
+    updateCards(data.cards || null);
+    const rows=Array.isArray(data.rows)?data.rows:[];
+    if(rows.length===0){
+      monthTableWrap.innerHTML='<div class="alert alert-info mb-0">ไม่พบข้อมูลในเดือนนี้</div>';
+      return;
+    }
+    const fmt=new Intl.NumberFormat(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
+    let html='<div class="card"><div class="card-body">';
+    html+=`<h5 class="card-title mb-3">รายการเดือน ${data.label ?? month} ${data.year}</h5>`;
+    html+='<div class="table-responsive"><table class="table table-striped table-hover align-middle">';
+    html+='<thead class="table-light"><tr><th>ID</th><th>วันเวลาที่ทำการจอง</th><th>วันเวลาที่เข้าใช้บริการ</th><th>Customer</th><th>Service</th><th>Staff</th><th class="text-end">ราคาก่อนหักส่วนลด</th><th class="text-end">ส่วนลด</th><th class="text-end">ราคาหลังหักส่วนลด</th><th>Status</th></tr></thead><tbody>';
+    rows.forEach(row=>{
+      html+=`<tr><td>${row.booking_id}</td><td>${row.booked_at}</td><td>${row.service_at}</td><td>${row.customer}</td><td>${row.services}</td><td>${row.staff}</td><td class="text-end">${fmt.format(row.gross)}</td><td class="text-end text-danger">-${fmt.format(row.discount)}</td><td class="text-end text-success">${fmt.format(row.net)}</td><td><span class="badge ${row.status_badge}">${row.status_label}</span></td></tr>`;
+    });
+    const totals=data.totals || {gross:0,discount:0,net:0};
+    html+='</tbody><tfoot><tr class="table-light"><th colspan="6" class="text-end">รวม</th>';
+    html+=`<th class="text-end">${fmt.format(totals.gross || 0)}</th><th class="text-end text-danger">-${fmt.format(totals.discount || 0)}</th><th class="text-end text-success">${fmt.format(totals.net || 0)}</th><th></th></tr></tfoot>`;
+    html+='</table></div></div></div>';
+    monthTableWrap.innerHTML=html;
+  }catch(err){
+    console.error(err);
+    monthTableWrap.innerHTML='<div class="alert alert-danger mb-0">ไม่สามารถโหลดข้อมูลได้</div>';
+  }
+}
+
+chartBackBtn?.addEventListener('click',()=>{
+  if(monthTableWrap) monthTableWrap.innerHTML='';
+  loadChart('years');
+});
+
+document.getElementById('chart-tab')?.addEventListener('shown.bs.tab',()=>{
+  if(!chart){
+    loadChart('years');
+  }
+});
 </script>
 </body>
 </html>

--- a/Admin/report_income.php
+++ b/Admin/report_income.php
@@ -9,6 +9,44 @@ $confirmedStatus = BOOKING_STATUS_CONFIRMED;
 $completedStatus = BOOKING_STATUS_COMPLATE;
 function esc($s){return htmlspecialchars($s??'',ENT_QUOTES,'UTF-8');}
 
+function getCardSums(mysqli $conn, string $whereSql, string $types = '', array $params = []): array {
+  $sql = "SELECT
+            COALESCE(SUM(b.final_price),0)       AS net,
+            COALESCE(SUM(b.total_price),0)       AS gross,
+            COALESCE(SUM(b.total_discount),0)    AS disc
+          FROM booking b
+          WHERE $whereSql";
+  $stmt = $conn->prepare($sql);
+  if($types !== ''){
+    $stmt->bind_param($types, ...$params);
+  }
+  $stmt->execute();
+  $row = $stmt->get_result()->fetch_assoc();
+  $stmt->close();
+  return [
+    'net' => (float)($row['net'] ?? 0),
+    'gross' => (float)($row['gross'] ?? 0),
+    'disc' => (float)($row['disc'] ?? 0)
+  ];
+}
+
+function getNetForMonth(mysqli $conn, string $whereSql, string $types, array $params, int $year, int $month): float {
+  $fullWhere = $whereSql . " AND YEAR(b.booking_date)=? AND MONTH(b.booking_date)=?";
+  $sql = "SELECT COALESCE(SUM(b.final_price),0) AS net FROM booking b WHERE $fullWhere";
+  $stmt = $conn->prepare($sql);
+  $fullTypes = $types . 'ii';
+  $fullParams = $params;
+  $fullParams[] = $year;
+  $fullParams[] = $month;
+  if($fullTypes !== ''){
+    $stmt->bind_param($fullTypes, ...$fullParams);
+  }
+  $stmt->execute();
+  $row = $stmt->get_result()->fetch_assoc();
+  $stmt->close();
+  return round((float)($row['net'] ?? 0), 2);
+}
+
 // ----------------------- Year range meta for chart pickers -----------------------
 $yr = $conn->query("SELECT MIN(YEAR(booking_date)) AS miny, MAX(YEAR(booking_date)) AS maxy FROM booking")->fetch_assoc();
 $minYear = (int)($yr['miny'] ?? date('Y'));
@@ -23,14 +61,6 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
   $view = in_array($view, ['years','months','month_table'], true) ? $view : 'years';
   $year = isset($_GET['year']) ? (int)$_GET['year'] : (int)date('Y');
   $month = isset($_GET['month']) ? (int)$_GET['month'] : (int)date('n');
-
-  // KPI cards (confirmed + completed)
-  $cardWhere = sprintf('status IN (%d,%d)', $confirmedStatus, $completedStatus);
-  $k_net_total = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
-  $k_gross_total = (float)$conn->query("SELECT COALESCE(SUM(total_price),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
-  $k_disc_total = (float)$conn->query("SELECT COALESCE(SUM(total_discount),0) s FROM booking WHERE $cardWhere")->fetch_assoc()['s'];
-  $ym = date('Y-m');
-  $k_net_mtd = (float)$conn->query("SELECT COALESCE(SUM(final_price),0) s FROM booking WHERE $cardWhere AND DATE_FORMAT(booking_date,'%Y-%m')='$ym'")->fetch_assoc()['s'];
 
   if($view === 'years'){
     $sql = "
@@ -51,17 +81,28 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
       $netSeries[]=round((float)$row['net'],2);
     }
 
+    $baseWhere = "b.status IN ($confirmedStatus,$completedStatus)";
+    $cardSums = getCardSums($conn, $baseWhere);
+    $cards = [
+      'net_total'   => round($cardSums['net'], 2),
+      'net_mtd'     => getNetForMonth($conn, $baseWhere, '', [], (int)date('Y'), (int)date('n')),
+      'gross_total' => round($cardSums['gross'], 2),
+      'disc_total'  => round($cardSums['disc'], 2)
+    ];
+    $cardLabels = [
+      'net_total'   => 'Net รวม (ทั้งหมด)',
+      'net_mtd'     => 'Net เดือนนี้',
+      'gross_total' => 'Gross รวม',
+      'disc_total'  => 'ส่วนลดรวม'
+    ];
+
     echo json_encode([
       'type'=>'years',
       'keys'=>$keys,
       'labels'=>$labels,
       'series'=>['net'=>$netSeries],
-      'cards'=>[
-        'net_total'=>$k_net_total,
-        'net_mtd'=>$k_net_mtd,
-        'gross_total'=>$k_gross_total,
-        'disc_total'=>$k_disc_total
-      ]
+      'cards'=>$cards,
+      'cardLabels'=>$cardLabels
     ]);
     exit;
   }
@@ -88,18 +129,34 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
       $netSeries[] = $map[$m] ?? 0;
     }
 
+    $whereSql = "b.status IN ($confirmedStatus,$completedStatus) AND YEAR(b.booking_date)=?";
+    $cardSums = getCardSums($conn, $whereSql, 'i', [$year]);
+    $activeMonths = array_filter($map, function($v){ return $v > 0; });
+    $avgPerMonth = 0.0;
+    if(count($activeMonths) > 0){
+      $avgPerMonth = array_sum($activeMonths) / count($activeMonths);
+    }
+    $cards = [
+      'net_total'   => round($cardSums['net'], 2),
+      'net_mtd'     => round($avgPerMonth, 2),
+      'gross_total' => round($cardSums['gross'], 2),
+      'disc_total'  => round($cardSums['disc'], 2)
+    ];
+    $cardLabels = [
+      'net_total'   => "Net รวมปี $year",
+      'net_mtd'     => "Net เฉลี่ยต่อเดือน (ปี $year)",
+      'gross_total' => "Gross รวมปี $year",
+      'disc_total'  => "ส่วนลดรวมปี $year"
+    ];
+
     echo json_encode([
       'type'=>'months',
       'year'=>$year,
       'keys'=>$keys,
       'labels'=>$labels,
       'series'=>['net'=>$netSeries],
-      'cards'=>[
-        'net_total'=>$k_net_total,
-        'net_mtd'=>$k_net_mtd,
-        'gross_total'=>$k_gross_total,
-        'disc_total'=>$k_disc_total
-      ]
+      'cards'=>$cards,
+      'cardLabels'=>$cardLabels
     ]);
     exit;
   }
@@ -165,23 +222,34 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
     }
     $stmt->close();
 
+    $count = count($rows);
+    $label = date('F', mktime(0,0,0,$month,1,$year));
+    $cards = [
+      'net_total'   => round($net, 2),
+      'net_mtd'     => $count > 0 ? round($net / $count, 2) : 0,
+      'gross_total' => round($gross, 2),
+      'disc_total'  => round($disc, 2)
+    ];
+    $cardLabels = [
+      'net_total'   => "Net รวมเดือน $label $year",
+      'net_mtd'     => "Net เฉลี่ยต่อรายการ ($count รายการ)",
+      'gross_total' => "Gross รวมเดือน $label $year",
+      'disc_total'  => "ส่วนลดรวมเดือน $label $year"
+    ];
+
     echo json_encode([
       'type'=>'month_table',
       'year'=>$year,
       'month'=>$month,
-      'label'=>date('F', mktime(0,0,0,$month,1,$year)),
+      'label'=>$label,
       'rows'=>$rows,
       'totals'=>[
         'gross'=>round($gross,2),
         'discount'=>round($disc,2),
         'net'=>round($net,2)
       ],
-      'cards'=>[
-        'net_total'=>$k_net_total,
-        'net_mtd'=>$k_net_mtd,
-        'gross_total'=>$k_gross_total,
-        'disc_total'=>$k_disc_total
-      ]
+      'cards'=>$cards,
+      'cardLabels'=>$cardLabels
     ]);
     exit;
   }
@@ -509,28 +577,28 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <div class="row mt-3">
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-cash-coin card-icon text-success"></i>
-            <div><div class="kpi-value" id="k_net_total">0</div><div class="text-muted">Net รวม (ยืนยันแล้ว)</div></div>
+            <div><div class="kpi-value" id="k_net_total">0</div><div class="text-muted" id="k_net_total_label">Net รวม (ยืนยันแล้ว)</div></div>
           </div></div></div>
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-graph-up card-icon text-primary"></i>
-            <div><div class="kpi-value" id="k_net_mtd">0</div><div class="text-muted">Net เดือนนี้</div></div>
+            <div><div class="kpi-value" id="k_net_mtd">0</div><div class="text-muted" id="k_net_mtd_label">Net เดือนนี้</div></div>
           </div></div></div>
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-receipt card-icon text-secondary"></i>
-            <div><div class="kpi-value" id="k_gross_total">0</div><div class="text-muted">Gross รวม</div></div>
+            <div><div class="kpi-value" id="k_gross_total">0</div><div class="text-muted" id="k_gross_total_label">Gross รวม</div></div>
           </div></div></div>
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-tag card-icon text-danger"></i>
-            <div><div class="kpi-value" id="k_disc_total">0</div><div class="text-muted">ส่วนลดรวม</div></div>
+            <div><div class="kpi-value" id="k_disc_total">0</div><div class="text-muted" id="k_disc_total_label">ส่วนลดรวม</div></div>
           </div></div></div>
         </div>
-        <div class="text-muted">* การ์ดไม่ใช้ตัวกรอง</div>
+        <div class="text-muted">* การ์ดอัปเดตตามข้อมูลที่แสดงในกราฟ</div>
 
         <!-- CHART -->
-        <div class="mt-3" style="min-height:380px">
+        <div class="mt-3" id="chartWrapper" style="min-height:380px">
           <canvas id="incomeChart" height="120"></canvas>
         </div>
-        <div class="text-muted mt-2">คลิกแท่งปีเพื่อดูรายเดือน และคลิกแท่งเดือนเพื่อดูตารางของเดือนนั้น</div>
+        <div class="text-muted mt-2" id="chartHint">คลิกแท่งปีเพื่อดูรายเดือน และคลิกแท่งเดือนเพื่อดูตารางของเดือนนั้น</div>
 
         <div id="monthTable" class="mt-4"></div>
 
@@ -561,23 +629,49 @@ const chartCanvas=document.getElementById('incomeChart');
 const chartCtx=chartCanvas?chartCanvas.getContext('2d'):null;
 const chartTitleEl=document.getElementById('chartTitle');
 const chartBackBtn=document.getElementById('chartBack');
+const chartWrapper=document.getElementById('chartWrapper');
+const chartHint=document.getElementById('chartHint');
 const monthTableWrap=document.getElementById('monthTable');
 let chart;
 let currentYear=null;
 
 const nf=(v)=>Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
 
-function updateCards(cards){
-  if(!cards) return;
-  const mapping={
-    k_net_total:cards.net_total,
-    k_net_mtd:cards.net_mtd,
-    k_gross_total:cards.gross_total,
-    k_disc_total:cards.disc_total
-  };
-  Object.entries(mapping).forEach(([id,val])=>{
-    const el=document.getElementById(id);
-    if(el) el.textContent=nf(val);
+function updateCards(cards, labels){
+  if(cards){
+    const mapping={
+      k_net_total:cards.net_total,
+      k_net_mtd:cards.net_mtd,
+      k_gross_total:cards.gross_total,
+      k_disc_total:cards.disc_total
+    };
+    Object.entries(mapping).forEach(([id,val])=>{
+      const el=document.getElementById(id);
+      if(el) el.textContent=nf(val);
+    });
+  }
+  if(labels){
+    const labelMap={
+      k_net_total_label:labels.net_total,
+      k_net_mtd_label:labels.net_mtd,
+      k_gross_total_label:labels.gross_total,
+      k_disc_total_label:labels.disc_total
+    };
+    Object.entries(labelMap).forEach(([id,text])=>{
+      if(typeof text === 'undefined') return;
+      const el=document.getElementById(id);
+      if(el) el.textContent=text;
+    });
+  }
+}
+
+function attachMonthTableBack(){
+  const backBtn=document.getElementById('monthTableBack');
+  if(!backBtn) return;
+  backBtn.addEventListener('click',()=>{
+    if(monthTableWrap) monthTableWrap.innerHTML='';
+    chartWrapper?.classList.remove('d-none');
+    chartHint?.classList.remove('d-none');
   });
 }
 
@@ -597,11 +691,8 @@ async function loadChart(view='years', year=null){
     }
     const res=await fetch(url.toString(),{cache:'no-store'});
     const data=await res.json();
-    updateCards(data.cards || null);
+    updateCards(data.cards || null, data.cardLabels || null);
     renderChart(data);
-    if(view==='years' && monthTableWrap){
-      monthTableWrap.innerHTML='';
-    }
   }catch(err){
     console.error(err);
   }
@@ -609,6 +700,9 @@ async function loadChart(view='years', year=null){
 
 function renderChart(data){
   if(!chartCtx) return;
+  chartWrapper?.classList.remove('d-none');
+  chartHint?.classList.remove('d-none');
+  if(monthTableWrap) monthTableWrap.innerHTML='';
   const labels=data.labels || [];
   const netSeries=data.series?.net || [];
   const keys=data.keys || [];
@@ -666,6 +760,8 @@ function renderChart(data){
 
 async function loadMonthTable(year, month){
   if(!monthTableWrap) return;
+  chartWrapper?.classList.add('d-none');
+  chartHint?.classList.add('d-none');
   monthTableWrap.innerHTML='<div class="text-muted">กำลังโหลด...</div>';
   try{
     const url=new URL(location.href);
@@ -676,15 +772,27 @@ async function loadMonthTable(year, month){
     url.searchParams.set('month',month);
     const res=await fetch(url.toString(),{cache:'no-store'});
     const data=await res.json();
-    updateCards(data.cards || null);
+    updateCards(data.cards || null, data.cardLabels || null);
     const rows=Array.isArray(data.rows)?data.rows:[];
+    const label=data.label ?? month;
+    const header=`
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h5 class="card-title mb-0">รายการเดือน ${label} ${data.year}</h5>
+  <button type="button" class="btn btn-outline-secondary btn-sm" id="monthTableBack">
+    <i class="bi bi-bar-chart"></i> กลับไปที่กราฟ
+  </button>
+</div>
+`.trim();
     if(rows.length===0){
-      monthTableWrap.innerHTML='<div class="alert alert-info mb-0">ไม่พบข้อมูลในเดือนนี้</div>';
+      monthTableWrap.innerHTML=`<div class="card"><div class="card-body">${header}
+  <div class="alert alert-info mb-0">ไม่พบข้อมูลในเดือนนี้</div>
+</div></div>`;
+      attachMonthTableBack();
       return;
     }
     const fmt=new Intl.NumberFormat(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
     let html='<div class="card"><div class="card-body">';
-    html+=`<h5 class="card-title mb-3">รายการเดือน ${data.label ?? month} ${data.year}</h5>`;
+    html+=header;
     html+='<div class="table-responsive"><table class="table table-striped table-hover align-middle">';
     html+='<thead class="table-light"><tr><th>ID</th><th>วันเวลาที่ทำการจอง</th><th>วันเวลาที่เข้าใช้บริการ</th><th>Customer</th><th>Service</th><th>Staff</th><th class="text-end">ราคาก่อนหักส่วนลด</th><th class="text-end">ส่วนลด</th><th class="text-end">ราคาหลังหักส่วนลด</th><th>Status</th></tr></thead><tbody>';
     rows.forEach(row=>{
@@ -695,14 +803,26 @@ async function loadMonthTable(year, month){
     html+=`<th class="text-end">${fmt.format(totals.gross || 0)}</th><th class="text-end text-danger">-${fmt.format(totals.discount || 0)}</th><th class="text-end text-success">${fmt.format(totals.net || 0)}</th><th></th></tr></tfoot>`;
     html+='</table></div></div></div>';
     monthTableWrap.innerHTML=html;
+    attachMonthTableBack();
   }catch(err){
     console.error(err);
-    monthTableWrap.innerHTML='<div class="alert alert-danger mb-0">ไม่สามารถโหลดข้อมูลได้</div>';
+    monthTableWrap.innerHTML=`<div class="card"><div class="card-body">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h5 class="card-title mb-0">ไม่สามารถโหลดข้อมูลได้</h5>
+    <button type="button" class="btn btn-outline-secondary btn-sm" id="monthTableBack">
+      <i class="bi bi-bar-chart"></i> กลับไปที่กราฟ
+    </button>
+  </div>
+  <div class="alert alert-danger mb-0">ไม่สามารถโหลดข้อมูลได้</div>
+</div></div>`;
+    attachMonthTableBack();
   }
 }
 
 chartBackBtn?.addEventListener('click',()=>{
   if(monthTableWrap) monthTableWrap.innerHTML='';
+  chartWrapper?.classList.remove('d-none');
+  chartHint?.classList.remove('d-none');
   loadChart('years');
 });
 

--- a/Admin/report_income.php
+++ b/Admin/report_income.php
@@ -634,6 +634,7 @@ const chartHint=document.getElementById('chartHint');
 const monthTableWrap=document.getElementById('monthTable');
 let chart;
 let currentYear=null;
+let lastChartState=null;
 
 const nf=(v)=>Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
 
@@ -665,6 +666,19 @@ function updateCards(cards, labels){
   }
 }
 
+function rememberChartState(data){
+  if(!data) return;
+  lastChartState={
+    cards:data.cards||null,
+    labels:data.cardLabels||null
+  };
+}
+
+function restoreChartCards(){
+  if(!lastChartState) return;
+  updateCards(lastChartState.cards || null, lastChartState.labels || null);
+}
+
 function attachMonthTableBack(){
   const backBtn=document.getElementById('monthTableBack');
   if(!backBtn) return;
@@ -672,6 +686,7 @@ function attachMonthTableBack(){
     if(monthTableWrap) monthTableWrap.innerHTML='';
     chartWrapper?.classList.remove('d-none');
     chartHint?.classList.remove('d-none');
+    restoreChartCards();
   });
 }
 
@@ -692,6 +707,7 @@ async function loadChart(view='years', year=null){
     const res=await fetch(url.toString(),{cache:'no-store'});
     const data=await res.json();
     updateCards(data.cards || null, data.cardLabels || null);
+    rememberChartState(data);
     renderChart(data);
   }catch(err){
     console.error(err);
@@ -702,6 +718,7 @@ function renderChart(data){
   if(!chartCtx) return;
   chartWrapper?.classList.remove('d-none');
   chartHint?.classList.remove('d-none');
+  rememberChartState(data);
   if(monthTableWrap) monthTableWrap.innerHTML='';
   const labels=data.labels || [];
   const netSeries=data.series?.net || [];


### PR DESCRIPTION
## Summary
- limit income report data to confirmed and completed bookings while updating filters, table columns, and sorting controls
- update the stats endpoint and client-side chart to provide year-to-month drilldowns for confirmed/completed revenue only
- render monthly booking details on chart interaction and refresh KPI cards without extra filters

## Testing
- php -l Admin/report_income.php

------
https://chatgpt.com/codex/tasks/task_e_68d542a711cc832da829f15a53097457