### PR TITLE
Align numeric table data to the right

### DIFF
--- a/Admin/assets/js/main.js
+++ b/Admin/assets/js/main.js
@@ -320,4 +320,30 @@ datatables.forEach(datatable => {
     }, 200);
   }
 
+  /**
+   * Align purely numeric table content to the right for better readability
+   */
+  const alignNumericTableCells = () => {
+    const numericPattern = /^[-+]?[\p{Sc}]?\s*(?:\d+(?:[.,]\d+)?|\d{1,3}(?:,\d{3})+(?:\.\d+)?)(?:\s*[\p{Sc}%])?$/u;
+
+    select('table', true).forEach(table => {
+      table.querySelectorAll('td, th').forEach(cell => {
+        const text = cell.textContent.trim();
+        if (!text) return;
+
+        // Normalise consecutive whitespaces to a single space for the regex test
+        const normalised = text.replace(/\s+/g, ' ');
+        if (numericPattern.test(normalised)) {
+          cell.classList.add('text-end');
+        }
+      });
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', alignNumericTableCells);
+  } else {
+    alignNumericTableCells();
+  }
+
 })();


### PR DESCRIPTION
## Summary
- automatically align numeric table cells to the right across admin tables for improved readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5c555bf18832d8b85b5d4a9f54344