### PR TITLE
Align final price column to right

### DIFF
--- a/Admin/table_booking.php
+++ b/Admin/table_booking.php
@@ -45,7 +45,7 @@ include("slidebar.php");
       <th>Customer</th>
       <th>Staff</th>
       <th>Service(s)</th>
-      <th>Final Price (€)</th>
+      <th class="text-end">Final Price (€)</th>
       <th>Status</th>
       <th>Detail</th>
       <th>Edit</th>
@@ -100,7 +100,7 @@ $sql = "
             <td>{$row['customer_name']}</td>
             <td>{$row['staff_name']}</td>
             <td>" . implode("<br>", $services) . "</td>
-            <td>€" . number_format($row['final_price'], 2) . "</td>
+            <td class='text-end'>€" . number_format($row['final_price'], 2) . "</td>
             <td>{$row['status']}</td>
             <td><a class='btn btn-outline-primary btn-sm' href='booking_detail.php?id={$row['booking_id']}'>Detail</a></td>
             <td><a class='btn btn-outline-warning btn-sm' href='booking_update_form.php?id={$row['booking_id']}'>Edit</a></td>

--- a/Admin/table_promotion.php
+++ b/Admin/table_promotion.php
@@ -72,8 +72,8 @@ $result = $conn->query($sql);
                       <th scope="col">วัน-เวลาเริ่มต้น</th>
                       <th scope="col">วัน-เวลาสิ้นสุด</th>
                       <th scope="col">สถานะ</th>
-                      <th scope="col">บริการที่เข้าร่วม</th>
-                      <th scope="col">ส่วนลดสูงสุด (%)</th>
+                      <th scope="col" class="text-end">บริการที่เข้าร่วม</th>
+                      <th scope="col" class="text-end">ส่วนลดสูงสุด (%)</th>
                       <th scope="col" class="text-center">การจัดการ</th>
                     </tr>
                   </thead>
@@ -109,8 +109,8 @@ $result = $conn->query($sql);
                               <?= htmlspecialchars($statusLabel) ?>
                             </span>
                           </td>
-                          <td><?= $serviceCount ?></td>
-                          <td><?= number_format((float) $maxPercent, 2) ?></td>
+                          <td class="text-end"><?= $serviceCount ?></td>
+                          <td class="text-end"><?= number_format((float) $maxPercent, 2) ?></td>
                           <td class="text-center">
                             <div class="d-flex justify-content-center flex-wrap gap-2">
                               <a


### PR DESCRIPTION
## Summary
- align the Final Price column header and data cells to the right using Bootstrap's text-end utility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c7f29438832dafed530ff954fdd6