### PR TITLE
Translate promotion table to English

### DIFF
--- a/Admin/promotion_utils.php
+++ b/Admin/promotion_utils.php
@@ -102,10 +102,10 @@ if (!function_exists('promotionStatusLabel')) {
     function promotionStatusLabel(string $status): string
     {
         return match ($status) {
-            'upcoming' => 'ยังไม่เริ่ม',
-            'running' => 'กำลังดำเนินการ',
-            'ended' => 'สิ้นสุด',
-            default => 'ไม่ทราบ',
+            'upcoming' => 'Upcoming',
+            'running' => 'Active',
+            'ended' => 'Ended',
+            default => 'Unknown',
         };
     }
 }

--- a/Admin/report_booking.php
+++ b/Admin/report_booking.php
@@ -170,9 +170,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
       'labels'   => $labels,
       'keys'     => $keys,
       'series'   => ['net'=>$values],
-      'axis'     => 'เดือน',
-      'title'    => "รายได้รายเดือน (ปี $year)",
-      'subtitle' => 'คลิกแท่งเดือนเพื่อดูรายได้รายวัน',
+      'axis'     => 'Months',
+      'title'    => "Monthly revenue (Year $year)",
+      'subtitle' => 'Click a month bar to view daily revenue',
       'cards'    => $cardsPayload
     ]);
     exit;
@@ -210,9 +210,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
       'labels'   => $labels,
       'keys'     => $keys,
       'series'   => ['net'=>$values],
-      'axis'     => 'วัน',
-      'title'    => "รายได้รายวัน (ปี $year เดือน $month)",
-      'subtitle' => 'คลิกแท่งวันเพื่อดูรายละเอียดการจอง',
+      'axis'     => 'Days',
+      'title'    => "Daily revenue (Year $year Month $month)",
+      'subtitle' => 'Click a day bar to view booking details',
       'cards'    => $cardsPayload
     ]);
     exit;
@@ -247,9 +247,9 @@ if(isset($_GET['action']) && $_GET['action']==='stats'){
     'labels'   => $labels,
     'keys'     => $keys,
     'series'   => ['net'=>$values],
-    'axis'     => 'ปี',
-    'title'    => 'รายได้รายปี',
-    'subtitle' => 'คลิกแท่งปีเพื่อดูรายได้รายเดือน',
+    'axis'     => 'Years',
+    'title'    => 'Annual revenue',
+    'subtitle' => 'Click a year bar to view monthly revenue',
     'cards'    => $cardsPayload
   ]);
   exit;
@@ -379,7 +379,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 };
 ?>
 <!doctype html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Booking Report</title>
@@ -401,12 +401,12 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 <?php include("slidebar.php"); ?>
 <main id="main" class="main">
 
-  <div class="pagetitle"><h1>รายงานการจอง (Booking)</h1></div>
+  <div class="pagetitle"><h1>Booking Report</h1></div>
 
   <!-- Tabs -->
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button" role="tab">ตาราง</button></li>
-    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" role="tab" id="chart-tab">กราฟ</button></li>
+    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button" role="tab">Table</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" role="tab" id="chart-tab">Chart</button></li>
   </ul>
 
   <div class="tab-content">
@@ -417,14 +417,14 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <form class="row g-2 align-items-end" method="get">
           <input type="hidden" name="tab" value="table">
           <div class="col-md-auto">
-            <label class="form-label small-label">ค้นหาจาก ID</label>
-            <input type="text" class="form-control" name="booking_id" value="<?=esc($searchId)?>" placeholder="เช่น 1001">
+            <label class="form-label small-label">Search by ID</label>
+            <input type="text" class="form-control" name="booking_id" value="<?=esc($searchId)?>" placeholder="e.g. 1001">
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">สถานะ</label>
+            <label class="form-label small-label">Status</label>
             <select class="form-select" name="status">
               <?php
-                $statusOptions = ['all' => 'ทั้งหมด'];
+                $statusOptions = ['all' => 'All'];
                 foreach (booking_status_options() as $code => $label) {
                   $statusOptions[(string)$code] = $label;
                 }
@@ -435,47 +435,47 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">บริการ</label>
+            <label class="form-label small-label">Service</label>
             <select class="form-select" name="service">
-              <option value="0">ทั้งหมด</option>
+              <option value="0">All</option>
               <?php while($sv=$serviceOps->fetch_assoc()): ?>
                 <option value="<?=$sv['service_id']?>" <?= $serviceF==$sv['service_id']?'selected':'' ?>><?=esc($sv['service_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">พนักงาน</label>
-            <select class="form-select select-search" name="staff" data-width="style" data-placeholder="เลือกพนักงาน" style="width:220px;">
-              <option value="0">ทั้งหมด</option>
+            <label class="form-label small-label">Staff</label>
+            <select class="form-select select-search" name="staff" data-width="style" data-placeholder="Select staff" style="width:220px;">
+              <option value="0">All</option>
               <?php while($s=$staffOps->fetch_assoc()): ?>
                 <option value="<?=$s['staff_id']?>" <?= $staffF==$s['staff_id']?'selected':'' ?>><?=esc($s['staff_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">ลูกค้า</label>
-            <select class="form-select select-search" name="customer" data-width="style" data-placeholder="เลือกลูกค้า" style="width:220px;">
-              <option value="0">ทั้งหมด</option>
+            <label class="form-label small-label">Customer</label>
+            <select class="form-select select-search" name="customer" data-width="style" data-placeholder="Select customer" style="width:220px;">
+              <option value="0">All</option>
               <?php while($cus=$customerOps->fetch_assoc()): ?>
                 <option value="<?=$cus['customer_id']?>" <?= $customerF==$cus['customer_id']?'selected':'' ?>><?=esc($cus['customer_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">ช่วงเวลา</label>
+            <label class="form-label small-label">Period</label>
             <select class="form-select" name="period" id="periodSelect">
               <option value="all" <?= $period==='all'?'selected':'' ?>>All</option>
-              <option value="date" <?= $period==='date'?'selected':'' ?>>รายวัน</option>
-              <option value="month" <?= $period==='month'?'selected':'' ?>>รายเดือน</option>
-              <option value="year" <?= $period==='year'?'selected':'' ?>>รายปี</option>
+              <option value="date" <?= $period==='date'?'selected':'' ?>>By day</option>
+              <option value="month" <?= $period==='month'?'selected':'' ?>>By month</option>
+              <option value="year" <?= $period==='year'?'selected':'' ?>>By year</option>
             </select>
           </div>
           <div class="col-md-auto period-control <?= $period==='date'?'':'d-none' ?>" id="period-date">
-            <label class="form-label small-label">เลือกวันที่</label>
+            <label class="form-label small-label">Select date</label>
             <input type="date" class="form-control" name="period_date" value="<?=esc($periodDate)?>">
           </div>
           <div class="col-md-auto period-control <?= $period==='month'?'':'d-none' ?>" id="period-month">
-            <label class="form-label small-label">เดือน / ปี</label>
+            <label class="form-label small-label">Month / Year</label>
             <div class="d-flex gap-2">
               <select class="form-select" name="period_month">
                 <?php for($m=1;$m<=12;$m++): ?>
@@ -490,7 +490,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </div>
           </div>
           <div class="col-md-auto period-control <?= $period==='year'?'':'d-none' ?>" id="period-year">
-            <label class="form-label small-label">เลือกปี</label>
+            <label class="form-label small-label">Select year</label>
             <select class="form-select" name="period_year">
               <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
                 <option value="<?=$y?>" <?= $periodYear==$y?'selected':'' ?>><?=$y?></option>
@@ -501,20 +501,20 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             <label class="form-label small-label">Sort by</label>
             <div class="input-group">
               <select class="form-select" name="sort">
-                <option value="booked_at" <?= $sort==='booked_at'?'selected':'' ?>>วันเวลาที่ทำการจอง</option>
-                <option value="service_time" <?= $sort==='service_time'?'selected':'' ?>>วันเวลาที่เข้าใช้บริการ</option>
+                <option value="booked_at" <?= $sort==='booked_at'?'selected':'' ?>>Booking created</option>
+                <option value="service_time" <?= $sort==='service_time'?'selected':'' ?>>Service time</option>
               </select>
               <select class="form-select" name="dir">
-                <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>เก่า → ใหม่</option>
-                <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>ใหม่ → เก่า</option>
+                <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>Oldest → newest</option>
+                <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>Newest → oldest</option>
               </select>
             </div>
           </div>
           <div class="col-md-auto">
-            <button class="btn btn-primary"><i class="bi bi-search"></i> ใช้ตัวกรอง</button>
+            <button class="btn btn-primary"><i class="bi bi-search"></i> Apply filters</button>
           </div>
           <div class="ms-auto col-md-auto">
-            <span class="badge bg-primary">รวม: <?=number_format($total)?> รายการ</span>
+            <span class="badge bg-primary">Total: <?=number_format($total)?> records</span>
           </div>
         </form>
 
@@ -523,20 +523,20 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             <thead class="table-light">
               <tr>
                 <th>ID</th>
-                <th>วันเวลาที่ทำการจอง</th>
-                <th>วันเวลาที่เข้าใช้บริการ</th>
-                <th>ลูกค้า</th>
-                <th>บริการ</th>
-                <th>พนักงาน</th>
-                <th class="text-end">ราคาก่อนหักส่วนลด</th>
-                <th class="text-end">ส่วนลด</th>
-                <th class="text-end">ราคาหลังหักส่วนลด</th>
-                <th>สถานะ</th>
+                <th>Booking created</th>
+                <th>Service time</th>
+                <th>Customer</th>
+                <th>Services</th>
+                <th>Staff</th>
+                <th class="text-end">Gross amount</th>
+                <th class="text-end">Discount</th>
+                <th class="text-end">Net amount</th>
+                <th>Status</th>
               </tr>
             </thead>
             <tbody>
               <?php if(empty($rows)): ?>
-                <tr><td colspan="10" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="10" class="text-center text-muted">No data found</td></tr>
               <?php else: foreach($rows as $bk): ?>
                 <?php
                   $bookedAt = $bk['b_created_at'] ? date('Y-m-d H:i', strtotime($bk['b_created_at'])) : '-';
@@ -579,17 +579,17 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 
         <?php if($pages > 1): ?>
         <div class="d-flex justify-content-between align-items-center mt-3">
-          <span class="text-muted">หน้า <?=number_format($page)?> / <?=number_format($pages)?></span>
+          <span class="text-muted">Page <?=number_format($page)?> / <?=number_format($pages)?></span>
           <div class="btn-group">
             <?php if($page > 1): ?>
-              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> ก่อนหน้า</a>
+              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> Previous</a>
             <?php else: ?>
-              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> ก่อนหน้า</span>
+              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> Previous</span>
             <?php endif; ?>
             <?php if($page < $pages): ?>
-              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">ถัดไป <i class="bi bi-chevron-right"></i></a>
+              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">Next <i class="bi bi-chevron-right"></i></a>
             <?php else: ?>
-              <span class="btn btn-outline-primary disabled">ถัดไป <i class="bi bi-chevron-right"></i></span>
+              <span class="btn btn-outline-primary disabled">Next <i class="bi bi-chevron-right"></i></span>
             <?php endif; ?>
           </div>
         </div>
@@ -605,37 +605,37 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <!-- Chart filters -->
         <div class="row g-3 align-items-end">
           <div class="col-md-auto">
-            <label class="form-label small-label">พนักงาน</label>
+            <label class="form-label small-label">Staff</label>
             <select id="chart_staff" class="form-select">
-              <option value="0">ทั้งหมด</option>
+              <option value="0">All</option>
               <?php $staffOps2 = $conn->query("SELECT staff_id, staff_name FROM staff ORDER BY staff_name"); while($s=$staffOps2->fetch_assoc()): ?>
                 <option value="<?=$s['staff_id']?>"><?=esc($s['staff_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">บริการ</label>
+            <label class="form-label small-label">Service</label>
             <select id="chart_service" class="form-select">
-              <option value="0">ทั้งหมด</option>
+              <option value="0">All</option>
               <?php $serviceOps2 = $conn->query("SELECT service_id, service_name FROM service ORDER BY service_name"); while($sv=$serviceOps2->fetch_assoc()): ?>
                 <option value="<?=$sv['service_id']?>"><?=esc($sv['service_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <button id="applyChart" class="btn btn-primary mt-4 mt-md-0"><i class="bi bi-funnel"></i> ใช้ตัวกรอง</button>
+            <button id="applyChart" class="btn btn-primary mt-4 mt-md-0"><i class="bi bi-funnel"></i> Apply filters</button>
           </div>
         </div>
 
         <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mt-3 gap-3">
           <div>
-            <h5 class="mb-1" id="chartTitle">รายได้รายปี</h5>
-            <div class="text-muted" id="chartSubtitle">คลิกแท่งเพื่อดูรายละเอียดระดับถัดไป</div>
+            <h5 class="mb-1" id="chartTitle">Annual revenue</h5>
+            <div class="text-muted" id="chartSubtitle">Click a bar to drill down to the next level</div>
           </div>
           <div class="d-flex flex-wrap align-items-center gap-2">
-            <span class="badge bg-secondary-subtle text-dark" id="chartLevel">ระดับ: รายปีทั้งหมด</span>
-            <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="backToYears"><i class="bi bi-arrow-counterclockwise"></i> ย้อนกลับระดับปี</button>
-            <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="backToMonths"><i class="bi bi-arrow-left-short"></i> ย้อนกลับระดับเดือน</button>
+            <span class="badge bg-secondary-subtle text-dark" id="chartLevel">Level: All years</span>
+            <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="backToYears"><i class="bi bi-arrow-counterclockwise"></i> Back to year level</button>
+            <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="backToMonths"><i class="bi bi-arrow-left-short"></i> Back to month level</button>
           </div>
         </div>
 
@@ -658,13 +658,13 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             <div><div class="kpi-value" id="k_canc">0</div><div class="text-muted">Cancelled</div></div>
           </div></div></div>
         </div>
-        <div class="text-muted">* การ์ดไม่ใช้ตัวกรอง</div>
+        <div class="text-muted">* Cards ignore the filters above</div>
 
         <!-- CHART -->
         <div class="mt-3" style="min-height:360px">
           <canvas id="bkChart" height="120"></canvas>
         </div>
-        <div class="text-muted mt-2">* คลิกแท่งเพื่อดูรายละเอียดระดับถัดไป หรือคลิกปุ่มย้อนกลับเพื่อกลับไปยังระดับก่อนหน้า</div>
+        <div class="text-muted mt-2">* Click a bar to view the next level, or use the back buttons to return</div>
 
         <div class="mt-4 d-none" id="dayTableWrap">
           <h5 id="dayTableHeading" class="mb-3"></h5>
@@ -673,23 +673,23 @@ $pageUrl = function(int $target) use ($baseQuery): string {
               <thead class="table-light">
                 <tr>
                   <th>ID</th>
-                  <th>เวลาบันทึก</th>
-                  <th>วัน/เวลาเข้าใช้บริการ</th>
-                  <th>ลูกค้า</th>
-                  <th>พนักงาน</th>
-                  <th>บริการ</th>
-                  <th class="text-end">ราคาก่อนส่วนลด</th>
-                  <th class="text-end">ส่วนลด</th>
-                  <th class="text-end">ยอดสุทธิ</th>
+                  <th>Booked at</th>
+                  <th>Service date/time</th>
+                  <th>Customer</th>
+                  <th>Staff</th>
+                  <th>Services</th>
+                  <th class="text-end">Gross</th>
+                  <th class="text-end">Discount</th>
+                  <th class="text-end">Net</th>
                 </tr>
               </thead>
               <tbody id="dayTableBody"></tbody>
             </table>
           </div>
           <div class="mt-3 text-end">
-            <div>ยอดรวมก่อนส่วนลด: <strong id="dayTotalsGross">฿0.00</strong></div>
-            <div>ส่วนลดรวม: <strong id="dayTotalsDiscount">฿0.00</strong></div>
-            <div>ยอดสุทธิรวม: <strong id="dayTotalsNet">฿0.00</strong></div>
+            <div>Total before discount: <strong id="dayTotalsGross">฿0.00</strong></div>
+            <div>Total discount: <strong id="dayTotalsDiscount">฿0.00</strong></div>
+            <div>Total net: <strong id="dayTotalsNet">฿0.00</strong></div>
           </div>
         </div>
 
@@ -714,8 +714,8 @@ function updatePeriodFilters(){
 periodSelect?.addEventListener('change',updatePeriodFilters);
 updatePeriodFilters();
 
-const currencyFmt = new Intl.NumberFormat('th-TH',{style:'currency',currency:'THB',maximumFractionDigits:2});
-const numberFmt = new Intl.NumberFormat('th-TH');
+const currencyFmt = new Intl.NumberFormat('en-US',{style:'currency',currency:'THB',maximumFractionDigits:2});
+const numberFmt = new Intl.NumberFormat('en-US');
 
 function formatCurrency(value){
   const num = typeof value === 'number' ? value : Number(value || 0);
@@ -726,7 +726,7 @@ function formatDateDisplay(iso){
   if(!iso) return '';
   const dt = new Date(iso + 'T00:00:00');
   if(Number.isNaN(dt.getTime())) return iso;
-  return dt.toLocaleDateString('th-TH',{dateStyle:'long'});
+  return dt.toLocaleDateString('en-US',{dateStyle:'long'});
 }
 
 let chart;
@@ -757,7 +757,7 @@ async function requestData(view, extra={}){
   if(extra.month !== undefined && extra.month !== null) params.set('month', extra.month);
   if(extra.day !== undefined && extra.day !== null) params.set('day', extra.day);
   const res = await fetch('report_booking.php?' + params.toString(), {cache:'no-store'});
-  if(!res.ok) throw new Error('ไม่สามารถดึงข้อมูลได้');
+  if(!res.ok) throw new Error('Unable to fetch data');
   return res.json();
 }
 
@@ -766,18 +766,18 @@ function updateBreadcrumb(){
   const backYears = document.getElementById('backToYears');
   const backMonths = document.getElementById('backToMonths');
   if(chartView==='years'){
-    levelEl.textContent = 'ระดับ: รายปีทั้งหมด';
+    levelEl.textContent = 'Level: All years';
     backYears?.classList.add('d-none');
     backMonths?.classList.add('d-none');
   }else if(chartView==='months'){
     const yearText = selectedYear ? selectedYear.toString() : '-';
-    levelEl.textContent = `ระดับ: ปี ${yearText}`;
+    levelEl.textContent = `Level: Year ${yearText}`;
     backYears?.classList.remove('d-none');
     backMonths?.classList.add('d-none');
   }else if(chartView==='days'){
     const yearText = selectedYear ? selectedYear.toString() : '-';
     const monthText = selectedMonth ? String(selectedMonth).padStart(2,'0') : '-';
-    levelEl.textContent = `ระดับ: ปี ${yearText} / เดือน ${monthText}`;
+    levelEl.textContent = `Level: Year ${yearText} / Month ${monthText}`;
     backYears?.classList.remove('d-none');
     backMonths?.classList.remove('d-none');
   }
@@ -786,7 +786,7 @@ function updateBreadcrumb(){
 function renderChart(data){
   const labels = data.labels ?? [];
   const values = data.series?.net ?? [];
-  document.getElementById('chartTitle').textContent = data.title || 'รายได้';
+  document.getElementById('chartTitle').textContent = data.title || 'Revenue';
   document.getElementById('chartSubtitle').textContent = data.subtitle || '';
 
   if(chart) chart.destroy();
@@ -796,7 +796,7 @@ function renderChart(data){
     data:{
       labels,
       datasets:[{
-        label:'รายได้ (บาท)',
+        label:'Revenue (THB)',
         data:values,
         backgroundColor:'#0d6efd',
         hoverBackgroundColor:'#0b5ed7',
@@ -813,7 +813,7 @@ function renderChart(data){
       },
       plugins:{
         legend:{display:false},
-        tooltip:{ callbacks:{ label:ctx=>`รายได้: ${formatCurrency(ctx.parsed.y)}` } }
+        tooltip:{ callbacks:{ label:ctx=>`Revenue: ${formatCurrency(ctx.parsed.y)}` } }
       },
       onClick:(evt,elements)=>{
         if(!elements?.length) return;
@@ -859,7 +859,7 @@ function renderDayTable(data){
     const td=document.createElement('td');
     td.colSpan=9;
     td.className='text-center text-muted';
-    td.textContent='ไม่มีข้อมูลสำหรับวันดังกล่าว';
+    td.textContent='No data for the selected day';
     tr.appendChild(td);
     body.appendChild(tr);
   }else{
@@ -888,7 +888,7 @@ function renderDayTable(data){
   const heading=document.getElementById('dayTableHeading');
   if(heading){
     const display=formatDateDisplay(data.date_iso);
-    heading.textContent=display ? `รายละเอียดรายได้วันที่ ${display}` : 'รายละเอียดรายได้รายวัน';
+    heading.textContent=display ? `Revenue details for ${display}` : 'Daily revenue details';
   }
   document.getElementById('dayTotalsGross').textContent = formatCurrency(data.totals?.gross ?? 0);
   document.getElementById('dayTotalsDiscount').textContent = formatCurrency(data.totals?.discount ?? 0);
@@ -973,7 +973,7 @@ $(function(){
       width:widthAttr,
       placeholder:placeholder,
       language:{
-        noResults:()=> 'ไม่พบข้อมูล'
+        noResults:()=> 'No results found'
       }
     });
   });

--- a/Admin/report_customer.php
+++ b/Admin/report_customer.php
@@ -47,19 +47,19 @@ if (isset($_GET['action']) && $_GET['action']==='stats') {
     $bucketExpr = "DATE_FORMAT(c_created_at,'%d')";
     $whereRange = "YEAR(c_created_at)=$year AND MONTH(c_created_at)=$month";
     $baseCutoff = sprintf('%04d-%02d-01', $year, $month);
-    $axis = 'วัน';
+    $axis = 'Days';
   } elseif ($period==='year') {
     $labels = ['01','02','03','04','05','06','07','08','09','10','11','12'];
     $bucketExpr = "DATE_FORMAT(c_created_at,'%m')";
     $whereRange = "YEAR(c_created_at)=$year";
     $baseCutoff = sprintf('%04d-01-01', $year);
-    $axis = 'เดือน';
+    $axis = 'Months';
   } else { // all
     for ($y=$start_year; $y<=$end_year; $y++) $labels[]=(string)$y;
     $bucketExpr = "YEAR(c_created_at)";
     $whereRange = "YEAR(c_created_at) BETWEEN $start_year AND $end_year";
     $baseCutoff = sprintf('%04d-01-01', $start_year);
-    $axis = 'ปี';
+    $axis = 'Years';
   }
 
   // counts per bucket by gender
@@ -235,7 +235,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 };
 ?>
 <!doctype html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Customer Report</title>
@@ -264,16 +264,16 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 <main id="main" class="main">
 
   <div class="pagetitle">
-    <h1>รายงานลูกค้า (Customer Report)</h1>
+    <h1>Customer Report</h1>
   </div>
 
   <!-- Tabs -->
   <ul class="nav nav-tabs nav-tabs-bordered" id="custTabs" role="tablist">
     <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="table-tab" data-bs-toggle="tab" data-bs-target="#tab-table" type="button" role="tab">ตาราง</button>
+      <button class="nav-link active" id="table-tab" data-bs-toggle="tab" data-bs-target="#tab-table" type="button" role="tab">Table</button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="chart-tab" data-bs-toggle="tab" data-bs-target="#tab-chart" type="button" role="tab">กราฟ</button>
+      <button class="nav-link" id="chart-tab" data-bs-toggle="tab" data-bs-target="#tab-chart" type="button" role="tab">Chart</button>
     </li>
   </ul>
 
@@ -286,35 +286,35 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             <form class="row g-2 align-items-end" method="get">
               <input type="hidden" name="tab" value="table">
               <div class="col-auto">
-                <label class="form-label small-label">ค้นหา</label>
-                <input type="text" class="form-control" name="q" value="<?= safe($search) ?>" placeholder="ID / ชื่อลูกค้า">
+                <label class="form-label small-label">Search</label>
+                <input type="text" class="form-control" name="q" value="<?= safe($search) ?>" placeholder="ID / Customer name">
               </div>
               <div class="col-auto">
-                <label class="form-label small-label">สถานะ</label>
+                <label class="form-label small-label">Status</label>
                 <select class="form-select" name="status">
-                  <option value="all"      <?= $status==='all'?'selected':'' ?>>ทั้งหมด</option>
+                  <option value="all"      <?= $status==='all'?'selected':'' ?>>All</option>
                   <option value="active"   <?= $status==='active'?'selected':'' ?>>Active</option>
                   <option value="inactive" <?= $status==='inactive'?'selected':'' ?>>Inactive</option>
                 </select>
               </div>
               <div class="col-auto">
-                <label class="form-label small-label">เพศ</label>
+                <label class="form-label small-label">Gender</label>
                 <select class="form-select" name="gender">
-                  <option value="all"    <?= $genderTable==='all'?'selected':'' ?>>ทั้งหมด</option>
+                  <option value="all"    <?= $genderTable==='all'?'selected':'' ?>>All</option>
                   <option value="male"   <?= $genderTable==='male'?'selected':'' ?>>male</option>
                   <option value="female" <?= $genderTable==='female'?'selected':'' ?>>female</option>
-                  <option value="other"  <?= $genderTable==='other'?'selected':'' ?>>other/ไม่ระบุ</option>
+                  <option value="other"  <?= $genderTable==='other'?'selected':'' ?>>other/unspecified</option>
                 </select>
               </div>
               <div class="col-auto">
-                <label class="form-label small-label">ช่วงอายุ</label>
+                <label class="form-label small-label">Age range</label>
                 <select class="form-select" name="age_range">
-                  <option value="all"     <?= $ageRange==='all'?'selected':'' ?>>ทั้งหมด</option>
-                  <option value="under20" <?= $ageRange==='under20'?'selected':'' ?>>ต่ำกว่า 20</option>
+                  <option value="all"     <?= $ageRange==='all'?'selected':'' ?>>All</option>
+                  <option value="under20" <?= $ageRange==='under20'?'selected':'' ?>>Under 20</option>
                   <option value="20_29"   <?= $ageRange==='20_29'?'selected':'' ?>>20-29</option>
                   <option value="30_39"   <?= $ageRange==='30_39'?'selected':'' ?>>30-39</option>
                   <option value="40_49"   <?= $ageRange==='40_49'?'selected':'' ?>>40-49</option>
-                  <option value="50plus"  <?= $ageRange==='50plus'?'selected':'' ?>>50 ขึ้นไป</option>
+                  <option value="50plus"  <?= $ageRange==='50plus'?'selected':'' ?>>50 and above</option>
                 </select>
               </div>
               <div class="col-auto">
@@ -322,20 +322,20 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                 <div class="input-group">
                   <select class="form-select" name="sort">
                     <option value="customer_id"   <?= $sort==='customer_id'?'selected':'' ?>>ID</option>
-                    <option value="customer_name" <?= $sort==='customer_name'?'selected':'' ?>>ชื่อ</option>
+                    <option value="customer_name" <?= $sort==='customer_name'?'selected':'' ?>>Name</option>
                   </select>
                   <select class="form-select" name="dir">
-                    <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>น้อย-มาก / A-Z</option>
-                    <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>มาก-น้อย / Z-A</option>
+                    <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>Ascending / A-Z</option>
+                    <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>>Descending / Z-A</option>
                   </select>
                 </div>
               </div>
               <div class="col-auto">
-                <button class="btn btn-primary"><i class="bi bi-search"></i> ใช้ตัวกรอง</button>
+                <button class="btn btn-primary"><i class="bi bi-search"></i> Apply filters</button>
               </div>
             </form>
             <div class="ms-auto">
-              <span class="badge bg-primary">จำนวนทั้งหมด: <?= number_format($totalRows) ?> ราย</span>
+              <span class="badge bg-primary">Total records: <?= number_format($totalRows) ?></span>
             </div>
           </div>
 
@@ -356,7 +356,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
               </thead>
               <tbody>
               <?php if(empty($rows)): ?>
-                <tr><td colspan="9" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="9" class="text-center text-muted">No data found</td></tr>
               <?php else: foreach($rows as $r):
                 $ageText = '-';
                 if ($r['age_years'] !== null) {
@@ -382,7 +382,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <td class="text-end"><span class="badge bg-primary"><?= number_format((int)$r['total_bookings']) ?></span></td>
                   <td class="text-end text-success fw-bold">฿<?= number_format((float)$r['total_spent'], 2) ?></td>
                   <td>
-                    <a href="customer_bookings.php?id=<?= (int)$r['customer_id'] ?>" class="btn btn-sm btn-outline-primary">ดูการจอง</a>
+                    <a href="customer_bookings.php?id=<?= (int)$r['customer_id'] ?>" class="btn btn-sm btn-outline-primary">View bookings</a>
                   </td>
                 </tr>
               <?php endforeach; endif; ?>
@@ -392,17 +392,17 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 
           <?php if ($pages > 1): ?>
           <div class="d-flex justify-content-between align-items-center mt-3">
-            <span class="text-muted">หน้า <?=number_format($page)?> / <?=number_format($pages)?></span>
+            <span class="text-muted">Page <?=number_format($page)?> / <?=number_format($pages)?></span>
             <div class="btn-group">
               <?php if ($page > 1): ?>
-                <a class="btn btn-outline-secondary" href="<?=safe($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> ก่อนหน้า</a>
+                <a class="btn btn-outline-secondary" href="<?=safe($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> Previous</a>
               <?php else: ?>
-                <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> ก่อนหน้า</span>
+                <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> Previous</span>
               <?php endif; ?>
               <?php if ($page < $pages): ?>
-                <a class="btn btn-outline-primary" href="<?=safe($pageUrl($page+1))?>">ถัดไป <i class="bi bi-chevron-right"></i></a>
+                <a class="btn btn-outline-primary" href="<?=safe($pageUrl($page+1))?>">Next <i class="bi bi-chevron-right"></i></a>
               <?php else: ?>
-                <span class="btn btn-outline-primary disabled">ถัดไป <i class="bi bi-chevron-right"></i></span>
+                <span class="btn btn-outline-primary disabled">Next <i class="bi bi-chevron-right"></i></span>
               <?php endif; ?>
             </div>
           </div>
@@ -419,7 +419,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
           <!-- Filters (legend toggles gender lines; keep series selector) -->
           <div class="row g-3 align-items-end">
             <div class="col-12 col-md-auto">
-              <label class="form-label small-label">ช่วงเวลา</label>
+              <label class="form-label small-label">Time range</label>
               <div class="btn-group" role="group">
                 <input type="radio" class="btn-check" name="period" id="p_all" value="all">
                 <label class="btn btn-outline-primary" for="p_all">All</label>
@@ -430,16 +430,16 @@ $pageUrl = function(int $target) use ($baseQuery): string {
               </div>
             </div>
             <div class="col-12 col-md-auto">
-              <label class="form-label small-label">ซี่รี่ส์ข้อมูล</label>
+              <label class="form-label small-label">Data series</label>
               <select id="series" class="form-select">
-                <option value="new" selected>สมัครใหม่</option>
-                <option value="total">ทั้งหมด (สะสม)</option>
+                <option value="new" selected>New sign-ups</option>
+                <option value="total">Total (cumulative)</option>
               </select>
             </div>
 
             <!-- Period-specific controls -->
             <div class="col-12 col-md-auto period-control" id="ctl-month">
-              <label class="form-label small-label">เดือน/ปี</label>
+              <label class="form-label small-label">Month / Year</label>
               <div class="d-flex gap-2">
                 <select id="month" class="form-select">
                   <?php for($m=1;$m<=12;$m++): ?>
@@ -452,21 +452,21 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <?php endfor; ?>
                 </select>
               </div>
-              <!-- <div class="form-text">แสดงรายวันของเดือนที่เลือก</div> -->
+              <!-- <div class="form-text">Shows daily totals for the selected month</div> -->
             </div>
 
             <div class="col-12 col-md-auto period-control d-none" id="ctl-year">
-              <label class="form-label small-label">ปี</label>
+              <label class="form-label small-label">Year</label>
               <select id="year_y" class="form-select">
                 <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
                 <option value="<?= $y ?>" <?= $y==(int)date('Y')?'selected':'' ?>><?= $y ?></option>
                 <?php endfor; ?>
               </select>
-              <!-- <div class="form-text">แสดงรายเดือนของปีที่เลือก</div> -->
+              <!-- <div class="form-text">Shows monthly totals for the selected year</div> -->
             </div>
 
             <div class="col-12 col-md-auto period-control d-none" id="ctl-all">
-              <label class="form-label small-label">ช่วงปี</label>
+              <label class="form-label small-label">Year range</label>
               <div class="d-flex gap-2">
                 <select id="start_year" class="form-select">
                   <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
@@ -479,11 +479,11 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <?php endfor; ?>
                 </select>
               </div>
-              <!-- <div class="form-text">แสดงรายปีตามช่วงที่เลือก</div> -->
+              <!-- <div class="form-text">Shows yearly totals for the selected range</div> -->
             </div>
 
             <div class="col-12 col-md-auto">
-              <button id="applyFilters" class="btn btn-primary"><i class="bi bi-filter"></i> ใช้ตัวกรอง</button>
+              <button id="applyFilters" class="btn btn-primary"><i class="bi bi-filter"></i> Apply filters</button>
             </div>
           </div>
 
@@ -495,7 +495,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <div class="card-icon bg-primary-light"><i class="bi bi-people fs-3 text-primary"></i></div>
                   <div>
                     <p class="kpi-value" id="kpi_total">0</p>
-                    <p class="kpi-label">จำนวนรวมทั้งหมด</p>
+                    <p class="kpi-label">Total customers</p>
                   </div>
                 </div>
               </div>
@@ -506,7 +506,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <div class="card-icon bg-success-light"><i class="bi bi-person-check fs-3 text-success"></i></div>
                   <div>
                     <p class="kpi-value" id="kpi_active">0</p>
-                    <p class="kpi-label">เฉพาะ Active</p>
+                    <p class="kpi-label">Active customers</p>
                   </div>
                 </div>
               </div>
@@ -517,7 +517,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                   <div class="card-icon bg-warning-light"><i class="bi bi-person-plus fs-3"></i></div>
                   <div>
                     <p class="kpi-value" id="kpi_new">0</p>
-                    <p class="kpi-label">New เดือนนี้</p>
+                    <p class="kpi-label">New this month</p>
                   </div>
                 </div>
               </div>
@@ -528,7 +528,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
           <div class="mt-3" style="min-height:360px">
             <canvas id="custLineChart" height="120"></canvas>
           </div>
-          <!-- <div class="legend-note mt-2">* คลิกสี่เหลี่ยมสีใน Legend เพื่อเปิด–ปิดเส้น (ทั้งหมด/ชาย/หญิง)</div> -->
+          <!-- <div class="legend-note mt-2">* Click a legend item to toggle the line (All/Male/Female)</div> -->
 
         </div>
       </div>
@@ -591,9 +591,9 @@ async function loadStats(){
     data:{
       labels,
       datasets:[
-        { label:'ทั้งหมด', data:seriesAll,    tension:.3, pointRadius:3, borderWidth:2 },
-        { label:'ชาย',     data:seriesMale,   tension:.3, pointRadius:3, borderWidth:2 },
-        { label:'หญิง',    data:seriesFemale, tension:.3, pointRadius:3, borderWidth:2 }
+        { label:'All',    data:seriesAll,    tension:.3, pointRadius:3, borderWidth:2 },
+        { label:'Male',   data:seriesMale,   tension:.3, pointRadius:3, borderWidth:2 },
+        { label:'Female', data:seriesFemale, tension:.3, pointRadius:3, borderWidth:2 }
       ]
     },
     options:{

--- a/Admin/report_promotion.php
+++ b/Admin/report_promotion.php
@@ -53,7 +53,7 @@ if ($action === 'stats') {
             $labels[] = str_pad((string)$d, 2, '0', STR_PAD_LEFT);
         }
         $bucketExpr = "DATE_FORMAT(b.booking_date,'%d')";
-        $axisLabel = 'วัน';
+        $axisLabel = 'Day';
         $rangeWhere[] = 'YEAR(b.booking_date) = ?';
         $typesRange .= 'i';
         $paramsRange[] = $year;
@@ -65,7 +65,7 @@ if ($action === 'stats') {
     } elseif ($period === 'year') {
         $labels = ['01','02','03','04','05','06','07','08','09','10','11','12'];
         $bucketExpr = "DATE_FORMAT(b.booking_date,'%m')";
-        $axisLabel = 'เดือน';
+        $axisLabel = 'Month';
         $rangeWhere[] = 'YEAR(b.booking_date) = ?';
         $typesRange .= 'i';
         $paramsRange[] = $year;
@@ -79,7 +79,7 @@ if ($action === 'stats') {
             $labels[] = (string)$y;
         }
         $bucketExpr = 'YEAR(b.booking_date)';
-        $axisLabel = 'ปี';
+        $axisLabel = 'Year';
         $rangeWhere[] = 'YEAR(b.booking_date) BETWEEN ? AND ?';
         $typesRange .= 'ii';
         $paramsRange[] = $startYear;
@@ -702,7 +702,7 @@ while ($pr = $res->fetch_assoc()) {
 $res->close();
 ?>
 <!doctype html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Promotion Report</title>
@@ -723,10 +723,10 @@ $res->close();
 <?php include('slidebar.php'); ?>
 <main id="main" class="main">
 
-  <div class="pagetitle"><h1>รายงานโปรโมชั่น (Promotion)</h1></div>
+  <div class="pagetitle"><h1>Promotion Report</h1></div>
 
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-table" type="button">ตาราง</button></li>
+    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-table" type="button">Table</button></li>
   </ul>
 
   <div class="tab-content">
@@ -738,60 +738,60 @@ $res->close();
           <form class="row g-2 align-items-end flex-grow-1" method="get">
             <input type="hidden" name="tab" value="table">
             <div class="col-sm-6 col-lg-3">
-              <label class="form-label small-label">ค้นหา (ID หรือชื่อ)</label>
-              <input type="text" class="form-control" name="q" value="<?=esc($search)?>" placeholder="เช่น 123 หรือ ชื่อโปรโมชั่น">
+              <label class="form-label small-label">Search (ID or name)</label>
+              <input type="text" class="form-control" name="q" value="<?=esc($search)?>" placeholder="e.g. 123 or promotion name">
             </div>
             <div class="col-sm-4 col-lg-2">
-              <label class="form-label small-label">สถานะโปรโมชั่น</label>
+              <label class="form-label small-label">Promotion status</label>
               <select class="form-select" name="promo_status">
-                <option value="all" <?= $promoStatus==='all'?'selected':'' ?>>ทั้งหมด</option>
-                <option value="running" <?= $promoStatus==='running'?'selected':'' ?>>กำลังใช้งาน</option>
-                <option value="upcoming" <?= $promoStatus==='upcoming'?'selected':'' ?>>รอเริ่ม</option>
-                <option value="ended" <?= $promoStatus==='ended'?'selected':'' ?>>สิ้นสุด</option>
+                <option value="all" <?= $promoStatus==='all'?'selected':'' ?>>All</option>
+                <option value="running" <?= $promoStatus==='running'?'selected':'' ?>>Running</option>
+                <option value="upcoming" <?= $promoStatus==='upcoming'?'selected':'' ?>>Upcoming</option>
+                <option value="ended" <?= $promoStatus==='ended'?'selected':'' ?>>Ended</option>
               </select>
             </div>
             <div class="col-sm-4 col-lg-2">
-              <label class="form-label small-label">ช่วงเวลา</label>
+              <label class="form-label small-label">Date range</label>
               <select class="form-select" name="period_type" id="period_type">
-                <option value="all" <?= $periodType==='all'?'selected':'' ?>>ทั้งหมด</option>
-                <option value="date" <?= $periodType==='date'?'selected':'' ?>>วันที่</option>
-                <option value="month" <?= $periodType==='month'?'selected':'' ?>>เดือน</option>
-                <option value="year" <?= $periodType==='year'?'selected':'' ?>>ปี</option>
+                <option value="all" <?= $periodType==='all'?'selected':'' ?>>All time</option>
+                <option value="date" <?= $periodType==='date'?'selected':'' ?>>Specific dates</option>
+                <option value="month" <?= $periodType==='month'?'selected':'' ?>>Month</option>
+                <option value="year" <?= $periodType==='year'?'selected':'' ?>>Year</option>
               </select>
             </div>
             <div class="col-sm-6 col-lg-3 period-input <?= $periodType==='date'?'':'d-none' ?>" data-period="date">
-              <label class="form-label small-label">เลือกวันที่</label>
+              <label class="form-label small-label">Choose date</label>
               <input type="date" class="form-control" name="period_date" value="<?=esc($periodDate)?>">
             </div>
             <div class="col-sm-6 col-lg-3 period-input <?= $periodType==='month'?'':'d-none' ?>" data-period="month">
-              <label class="form-label small-label">เลือกเดือน</label>
+              <label class="form-label small-label">Choose month</label>
               <input type="month" class="form-control" name="period_month" value="<?=esc($periodMonth)?>">
             </div>
             <div class="col-sm-4 col-lg-2 period-input <?= $periodType==='year'?'':'d-none' ?>" data-period="year">
-              <label class="form-label small-label">เลือกปี</label>
+              <label class="form-label small-label">Choose year</label>
               <input type="number" class="form-control" name="period_year" value="<?=esc($periodYear)?>" min="2000" max="2100" step="1">
             </div>
             <div class="col-sm-6 col-lg-3">
               <label class="form-label small-label">Sort by</label>
               <div class="d-flex gap-2">
                 <select class="form-select" name="sort" id="sort_field">
-                  <option value="name" <?= $sort==='name'?'selected':'' ?>>ชื่อ</option>
-                  <option value="popularity" <?= $sort==='popularity'?'selected':'' ?>>ความนิยม</option>
+                  <option value="name" <?= $sort==='name'?'selected':'' ?>>Name</option>
+                  <option value="popularity" <?= $sort==='popularity'?'selected':'' ?>>Popularity</option>
                 </select>
                 <select class="form-select" name="dir" id="sort_direction">
-                  <option value="ASC" <?= $dir==='ASC'?'selected':'' ?>><?= $sort==='name' ? 'A - Z' : 'น้อยไปมาก' ?></option>
-                  <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>><?= $sort==='name' ? 'Z - A' : 'มากไปน้อย' ?></option>
+                  <option value="ASC" <?= $dir==='ASC'?'selected':'' ?>><?= $sort==='name' ? 'A - Z' : 'Low to High' ?></option>
+                  <option value="DESC" <?= $dir==='DESC'?'selected':'' ?>><?= $sort==='name' ? 'Z - A' : 'High to Low' ?></option>
                 </select>
               </div>
             </div>
             <div class="col-auto">
-              <button class="btn btn-primary"><i class="bi bi-search"></i> ใช้ตัวกรอง</button>
+              <button class="btn btn-primary"><i class="bi bi-search"></i> Apply filters</button>
             </div>
           </form>
           <div class="ms-auto d-flex flex-column flex-sm-row align-items-sm-center gap-2 mt-3 mt-sm-0">
-            <span class="badge bg-primary">โปรโมชั่น: <?=number_format($totalRows)?></span>
-            <span class="badge bg-info text-dark">จำนวนการใช้รวมหน้านี้ <?=number_format($tableTotals['booking_count'])?></span>
-            <span class="badge bg-danger">ส่วนลดรวมหน้านี้ -<?=number_format($tableTotals['discount_sum'],2)?></span>
+            <span class="badge bg-primary">Promotions: <?=number_format($totalRows)?></span>
+            <span class="badge bg-info text-dark">Usage (this page) <?=number_format($tableTotals['booking_count'])?></span>
+            <span class="badge bg-danger">Discount total (this page) -<?=number_format($tableTotals['discount_sum'],2)?></span>
           </div>
         </div>
 
@@ -800,17 +800,17 @@ $res->close();
             <thead class="table-light">
               <tr>
                 <th>ID</th>
-                <th>ชื่อโปรโมชั่น</th>
-                <th>สถานะ</th>
-                <th>ช่วงเวลา</th>
-                <th class="text-center">บริการ</th>
-                <th class="text-end">จำนวนการใช้</th>
-                <th class="text-end">ส่วนลดทั้งหมด</th>
+                <th>Promotion name</th>
+                <th>Status</th>
+                <th>Period</th>
+                <th class="text-center">Services</th>
+                <th class="text-end">Usage count</th>
+                <th class="text-end">Total discount</th>
               </tr>
             </thead>
             <tbody id="promotionTableBody">
               <?php if (empty($rows)): ?>
-                <tr><td colspan="7" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="7" class="text-center text-muted">No data found</td></tr>
               <?php else: foreach ($rows as $row):
                 $status = promotionStatus($row['pm_start_date'] ?? '', $row['pm_end_date'] ?? '');
                 $badgeClass = promotion_status_badge_class($status);
@@ -831,7 +831,7 @@ $res->close();
                 <td><span class="badge <?=$badgeClass?>"><?= esc($statusLabel) ?></span></td>
                 <td>
                   <div><?= esc(formatDateTimeDisplay($row['pm_start_date'] ?? '')) ?></div>
-                  <div class="text-muted small">ถึง <?= esc(formatDateTimeDisplay($row['pm_end_date'] ?? '')) ?></div>
+                  <div class="text-muted small">to <?= esc(formatDateTimeDisplay($row['pm_end_date'] ?? '')) ?></div>
                 </td>
                 <td class="text-center">
                   <?php if ($serviceCount > 0): ?>
@@ -854,7 +854,7 @@ $res->close();
             <?php if (!empty($rows)): ?>
             <tfoot>
               <tr class="table-light">
-                <th colspan="5" class="text-end">รวม (เฉพาะรายการในหน้านี้)</th>
+                <th colspan="5" class="text-end">Total (this page)</th>
                 <th class="text-end"><?= number_format($tableTotals['booking_count']) ?></th>
                 <th class="text-end text-danger">-<?= number_format($tableTotals['discount_sum'], 2) ?></th>
               </tr>
@@ -865,17 +865,17 @@ $res->close();
 
         <?php if ($pages > 1): ?>
         <div class="d-flex justify-content-between align-items-center mt-3">
-          <span class="text-muted">หน้า <?=number_format($page)?> / <?=number_format($pages)?></span>
+          <span class="text-muted">Page <?=number_format($page)?> / <?=number_format($pages)?></span>
           <div class="btn-group">
             <?php if ($page > 1): ?>
-              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> ก่อนหน้า</a>
+              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> Previous</a>
             <?php else: ?>
-              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> ก่อนหน้า</span>
+              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> Previous</span>
             <?php endif; ?>
             <?php if ($page < $pages): ?>
-              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">ถัดไป <i class="bi bi-chevron-right"></i></a>
+              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">Next <i class="bi bi-chevron-right"></i></a>
             <?php else: ?>
-              <span class="btn btn-outline-primary disabled">ถัดไป <i class="bi bi-chevron-right"></i></span>
+              <span class="btn btn-outline-primary disabled">Next <i class="bi bi-chevron-right"></i></span>
             <?php endif; ?>
           </div>
         </div>
@@ -889,11 +889,11 @@ $res->close();
               <h5 class="mb-1" id="usageTitle">-</h5>
               <div class="text-muted small" id="usageRange"></div>
             </div>
-            <button type="button" class="btn btn-outline-secondary" id="usageBack"><i class="bi bi-arrow-left"></i> กลับไปตาราง</button>
+            <button type="button" class="btn btn-outline-secondary" id="usageBack"><i class="bi bi-arrow-left"></i> Back to table</button>
           </div>
           <div class="mb-3 d-flex flex-wrap gap-2">
-            <span class="badge bg-primary">จำนวนการใช้ทั้งหมด <span id="usageTotal">0</span></span>
-            <span class="badge bg-danger">ส่วนลดรวม <span id="usageDiscount">0.00</span></span>
+            <span class="badge bg-primary">Total usage <span id="usageTotal">0</span></span>
+            <span class="badge bg-danger">Total discount <span id="usageDiscount">0.00</span></span>
           </div>
           <div class="ratio ratio-16x9">
             <canvas id="usageLineChart"></canvas>
@@ -911,12 +911,12 @@ $res->close();
   <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="serviceModalLabel">รายละเอียดบริการ</h5>
+        <h5 class="modal-title" id="serviceModalLabel">Service details</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div id="serviceModalContent" class="vstack gap-3">
-          <div class="text-center text-muted">กำลังโหลด...</div>
+          <div class="text-center text-muted">Loading...</div>
         </div>
       </div>
     </div>
@@ -948,8 +948,8 @@ function updateSortDirectionLabels(){
     asc.textContent='A - Z';
     desc.textContent='Z - A';
   }else{
-    asc.textContent='น้อยไปมาก';
-    desc.textContent='มากไปน้อย';
+    asc.textContent='Low to High';
+    desc.textContent='High to Low';
   }
 }
 sortField?.addEventListener('change',updateSortDirectionLabels);
@@ -985,15 +985,15 @@ const serviceModalContent=document.getElementById('serviceModalContent');
 
 const nf0=v=>Number(v||0).toLocaleString();
 const nf2=v=>Number(v||0).toLocaleString(undefined,{minimumFractionDigits:2,maximumFractionDigits:2});
-function formatThaiDate(str){
+function formatDisplayDate(str){
   if(!str) return '-';
   const match=/^(\d{4})-(\d{2})-(\d{2})/.exec(str);
   if(!match) return str;
   const year=parseInt(match[1],10);
-  const month=match[2];
-  const day=match[3];
-  if(Number.isNaN(year)) return str;
-  return `${day}/${month}/${year+543}`;
+  const month=parseInt(match[2],10);
+  const day=parseInt(match[3],10);
+  if(Number.isNaN(year)||Number.isNaN(month)||Number.isNaN(day)) return str;
+  return new Date(year,month-1,day).toLocaleDateString(undefined,{year:'numeric',month:'short',day:'2-digit'});
 }
 
 const tableBody=document.getElementById('promotionTableBody');
@@ -1002,8 +1002,8 @@ tableBody?.addEventListener('click',async event=>{
   if(serviceBtn){
     if(!serviceModal||!serviceModalContent) return;
     const promotionId=serviceBtn.dataset.promotionId||'';
-    serviceModalLabel.textContent=`รายละเอียดบริการ - ${serviceBtn.dataset.promotionName||''}`;
-    serviceModalContent.innerHTML='<div class="text-center text-muted py-3">กำลังโหลด...</div>';
+    serviceModalLabel.textContent=`Service details - ${serviceBtn.dataset.promotionName||''}`;
+    serviceModalContent.innerHTML='<div class="text-center text-muted py-3">Loading...</div>';
     serviceModal.show();
     try{
       const url=new URL(location.href);
@@ -1017,7 +1017,7 @@ tableBody?.addEventListener('click',async event=>{
       const data=await res.json();
       const services=Array.isArray(data.services)?data.services:[];
       if(services.length===0){
-        serviceModalContent.innerHTML='<div class="text-center text-muted py-3">ไม่มีข้อมูลบริการสำหรับโปรโมชั่นนี้</div>';
+        serviceModalContent.innerHTML='<div class="text-center text-muted py-3">No services are linked to this promotion.</div>';
         return;
       }
       serviceModalContent.innerHTML='';
@@ -1026,14 +1026,14 @@ tableBody?.addEventListener('click',async event=>{
         wrapper.className='border rounded p-3';
         const title=document.createElement('h6');
         title.className='mb-2';
-        title.textContent=service.service_name||'ไม่ระบุบริการ';
+        title.textContent=service.service_name||'Unnamed service';
         wrapper.appendChild(title);
         const stack=document.createElement('div');
         stack.className='vstack gap-2';
         (service.options||[]).forEach(option=>{
           const item=document.createElement('div');
           item.className='border rounded p-2';
-          const duration=option.duration?`${option.duration} นาที`:'ตัวเลือกบริการ';
+          const duration=option.duration?`${option.duration} minutes`:'Service option';
           const basePrice=nf2(option.price);
           const finalPrice=nf2(option.final_price||option.price);
           const percent=Number(option.discount_percent||0);
@@ -1041,16 +1041,16 @@ tableBody?.addEventListener('click',async event=>{
           const discountParts=[];
           if(percent>0){discountParts.push(`${percent}%`);}
           if(amount>0){discountParts.push(`฿${nf2(amount)}`);}
-          const discountText=discountParts.length>0?discountParts.join(' / '):'ไม่มีส่วนลด';
+          const discountText=discountParts.length>0?discountParts.join(' / '):'No discount';
           item.innerHTML=
             `<div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
                <div>
                  <div class="fw-semibold">${duration}</div>
-                 <div class="text-muted small">ราคาเดิม ฿${basePrice}</div>
+                 <div class="text-muted small">Base price ฿${basePrice}</div>
                </div>
                <div class="text-end">
                  <div class="text-danger fw-semibold">-${discountText}</div>
-                 <div class="text-success small">ราคาใหม่ ฿${finalPrice}</div>
+                 <div class="text-success small">New price ฿${finalPrice}</div>
                </div>
              </div>`;
           stack.appendChild(item);
@@ -1058,7 +1058,7 @@ tableBody?.addEventListener('click',async event=>{
         if(!stack.childElementCount){
           const empty=document.createElement('div');
           empty.className='text-muted small';
-          empty.textContent='ไม่มีตัวเลือกบริการที่ร่วมโปรโมชั่น';
+          empty.textContent='No service options are linked to this promotion.';
           stack.appendChild(empty);
         }
         wrapper.appendChild(stack);
@@ -1066,7 +1066,7 @@ tableBody?.addEventListener('click',async event=>{
       });
     }catch(err){
       console.error(err);
-      serviceModalContent.innerHTML='<div class="text-center text-danger py-3">ไม่สามารถโหลดข้อมูลบริการได้</div>';
+      serviceModalContent.innerHTML='<div class="text-center text-danger py-3">Unable to load service data.</div>';
     }
     return;
   }
@@ -1074,8 +1074,8 @@ tableBody?.addEventListener('click',async event=>{
   const usageBtn=event.target.closest('.usage-chart-btn');
   if(usageBtn){
     event.preventDefault();
-    usageTitle.textContent=`การใช้โปรโมชั่น: ${usageBtn.dataset.promotionName||''}`;
-    usageRange.textContent='กำลังโหลดข้อมูล...';
+    usageTitle.textContent=`Promotion usage: ${usageBtn.dataset.promotionName||''}`;
+    usageRange.textContent='Loading data...';
     usageTotal.textContent='0';
     usageDiscount.textContent='0.00';
     usageView?.classList.remove('d-none');
@@ -1096,7 +1096,7 @@ tableBody?.addEventListener('click',async event=>{
       const data=await res.json();
       const labels=Array.isArray(data.chart?.labels)?data.chart.labels:[];
       const usageData=Array.isArray(data.chart?.usage)?data.chart.usage:[];
-      usageRange.textContent=`ช่วง ${formatThaiDate(data.promotion?.start)} - ${formatThaiDate(data.promotion?.end)}`;
+      usageRange.textContent=`Range ${formatDisplayDate(data.promotion?.start)} - ${formatDisplayDate(data.promotion?.end)}`;
       usageTotal.textContent=nf0(data.summary?.total_usage||0);
       usageDiscount.textContent=`-${nf2(data.summary?.total_discount||0)}`;
       if(usageCanvas){
@@ -1106,7 +1106,7 @@ tableBody?.addEventListener('click',async event=>{
           data:{
             labels,
             datasets:[{
-              label:'จำนวนการใช้',
+              label:'Usage count',
               data:usageData,
               borderColor:'#0d6efd',
               backgroundColor:'rgba(13,110,253,0.15)',
@@ -1119,8 +1119,8 @@ tableBody?.addEventListener('click',async event=>{
             responsive:true,
             maintainAspectRatio:false,
             scales:{
-              x:{title:{display:true,text:'ช่วงเวลา'}},
-              y:{beginAtZero:true,title:{display:true,text:'จำนวนการใช้'}}
+              x:{title:{display:true,text:'Timeline'}},
+              y:{beginAtZero:true,title:{display:true,text:'Usage count'}}
             },
             plugins:{
               legend:{display:true},
@@ -1131,7 +1131,7 @@ tableBody?.addEventListener('click',async event=>{
       }
     }catch(err){
       console.error(err);
-      usageRange.textContent='ไม่สามารถโหลดกราฟได้';
+      usageRange.textContent='Unable to load the chart.';
     }
   }
 });

--- a/Admin/report_service.php
+++ b/Admin/report_service.php
@@ -193,7 +193,7 @@ if (isset($_GET['action'])) {
       if ($startYear > $endYear) { [$startYear,$endYear] = [$endYear,$startYear]; }
       for($y=$startYear;$y<=$endYear;$y++){ $labels[] = (string)$y; }
       $bucketExpr = "YEAR(b.booking_date)";
-      $axis = 'ปี';
+      $axis = 'Year';
     } elseif ($period === 'year') {
       $start = date_create($rangeStart);
       $start->modify('first day of this month');
@@ -204,7 +204,7 @@ if (isset($_GET['action'])) {
         $start->modify('+1 month');
       }
       $bucketExpr = "DATE_FORMAT(b.booking_date,'%Y-%m')";
-      $axis = 'เดือน';
+      $axis = 'Month';
     } else {
       $start = date_create($rangeStart);
       $end = date_create($rangeEnd);
@@ -214,7 +214,7 @@ if (isset($_GET['action'])) {
         $start->modify('+1 day');
       }
       $bucketExpr = "DATE_FORMAT(b.booking_date,'%Y-%m-%d')";
-      $axis = 'วัน';
+      $axis = 'Day';
     }
 
     $dateCond = " AND b.booking_date >= '".$conn->real_escape_string($rangeStart)."' AND b.booking_date <= '".$conn->real_escape_string($rangeEnd)."'";
@@ -377,7 +377,7 @@ $tableYearStartVal = $tablePeriod === 'year' && $tableRangeStart ? (int)substr($
 $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($tableRangeEnd,0,4)   : $maxYear;
 ?>
 <!doctype html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Service Report</title>
@@ -398,12 +398,12 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
 <?php include("slidebar.php"); ?>
 <main id="main" class="main">
 
-  <div class="pagetitle"><h1>รายงานบริการ (Service Report)</h1></div>
+  <div class="pagetitle"><h1>Service Report</h1></div>
 
   <!-- Tabs -->
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button">ตาราง</button></li>
-    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" id="chart-tab">กราฟ</button></li>
+    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button">Table</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" id="chart-tab">Chart</button></li>
   </ul>
 
   <div class="tab-content">
@@ -414,36 +414,36 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
         <form class="row g-3 align-items-end" method="get" id="tableFilters">
           <input type="hidden" name="tab" value="table">
           <div class="col-lg-3 col-md-4">
-            <label class="form-label small-label">ค้นหา (ID หรือชื่อบริการ)</label>
-            <input type="text" class="form-control" name="q" value="<?=esc($tableSearch)?>" placeholder="ค้นหาบริการ" data-autosubmit>
+            <label class="form-label small-label">Search (ID or service name)</label>
+            <input type="text" class="form-control" name="q" value="<?=esc($tableSearch)?>" placeholder="Search services" data-autosubmit>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">สถานะบริการ</label>
+            <label class="form-label small-label">Service status</label>
             <select class="form-select" name="service_status">
-              <option value="all" <?= $tableStatus==='all'?'selected':'' ?>>ทั้งหมด</option>
-              <option value="active" <?= $tableStatus==='active'?'selected':'' ?>>เปิดใช้งาน</option>
-              <option value="inactive" <?= $tableStatus==='inactive'?'selected':'' ?>>ปิดใช้งาน</option>
+              <option value="all" <?= $tableStatus==='all'?'selected':'' ?>>All</option>
+              <option value="active" <?= $tableStatus==='active'?'selected':'' ?>>Active</option>
+              <option value="inactive" <?= $tableStatus==='inactive'?'selected':'' ?>>Inactive</option>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label">ช่วงข้อมูล</label>
+            <label class="form-label small-label">Data range</label>
             <select class="form-select" name="table_period" id="tablePeriod">
-              <option value="all" <?= $tablePeriod==='all'?'selected':'' ?>>ทั้งหมด</option>
-              <option value="day" <?= $tablePeriod==='day'?'selected':'' ?>>ช่วงวัน</option>
-              <option value="month" <?= $tablePeriod==='month'?'selected':'' ?>>ช่วงเดือน</option>
-              <option value="year" <?= $tablePeriod==='year'?'selected':'' ?>>ช่วงปี</option>
+              <option value="all" <?= $tablePeriod==='all'?'selected':'' ?>>All time</option>
+              <option value="day" <?= $tablePeriod==='day'?'selected':'' ?>>Day range</option>
+              <option value="month" <?= $tablePeriod==='month'?'selected':'' ?>>Month range</option>
+              <option value="year" <?= $tablePeriod==='year'?'selected':'' ?>>Year range</option>
             </select>
           </div>
           <div class="col-lg-4 col-md-6 period-control <?= $tablePeriod==='day'?'':'d-none' ?>" id="tablePeriodDay">
-            <label class="form-label small-label">เลือกวัน</label>
+            <label class="form-label small-label">Select dates</label>
             <div class="d-flex flex-wrap gap-2">
               <input type="date" class="form-control" name="day_start" value="<?=esc($tableDayStartVal)?>">
-              <span class="align-self-center small text-muted">ถึง</span>
+              <span class="align-self-center small text-muted">to</span>
               <input type="date" class="form-control" name="day_end" value="<?=esc($tableDayEndVal)?>">
             </div>
           </div>
           <div class="col-lg-5 col-md-6 period-control <?= $tablePeriod==='month'?'':'d-none' ?>" id="tablePeriodMonth">
-            <label class="form-label small-label">เลือกเดือน</label>
+            <label class="form-label small-label">Select months</label>
             <div class="d-flex flex-wrap gap-2 align-items-center">
               <div class="d-flex gap-2">
                 <select class="form-select" name="month_start">
@@ -457,7 +457,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
                   <?php endfor; ?>
                 </select>
               </div>
-              <span class="small text-muted">ถึง</span>
+              <span class="small text-muted">to</span>
               <div class="d-flex gap-2">
                 <select class="form-select" name="month_end">
                   <?php for($m=1;$m<=12;$m++): ?>
@@ -473,7 +473,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             </div>
           </div>
           <div class="col-md-auto period-control <?= $tablePeriod==='year'?'':'d-none' ?>" id="tablePeriodYear">
-            <label class="form-label small-label">ช่วงปี</label>
+            <label class="form-label small-label">Year span</label>
             <div class="d-flex gap-2">
               <select class="form-select" name="year_start">
                 <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
@@ -491,10 +491,10 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             <label class="form-label small-label">Sort by</label>
             <div class="input-group">
               <select class="form-select" name="sort_field" id="sortField">
-                <option value="name" <?= $tableSortField==='name'?'selected':'' ?>>ชื่อ</option>
-                <option value="popularity" <?= $tableSortField==='popularity'?'selected':'' ?>>ความนิยม (จำนวนจอง)</option>
-                <option value="price" <?= $tableSortField==='price'?'selected':'' ?>>ราคาเริ่มต้น</option>
-                <option value="option" <?= $tableSortField==='option'?'selected':'' ?>>จำนวนออปชัน</option>
+                <option value="name" <?= $tableSortField==='name'?'selected':'' ?>>Name</option>
+                <option value="popularity" <?= $tableSortField==='popularity'?'selected':'' ?>>Bookings (popularity)</option>
+                <option value="price" <?= $tableSortField==='price'?'selected':'' ?>>Starting price</option>
+                <option value="option" <?= $tableSortField==='option'?'selected':'' ?>>Options count</option>
               </select>
               <select class="form-select" name="sort_dir" id="sortDir">
                 <option value="ASC" <?= $tableSortDir==='ASC'?'selected':'' ?>>ASC</option>
@@ -503,10 +503,10 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             </div>
           </div>
           <div class="col-md-auto">
-            <button class="btn btn-primary"><i class="bi bi-search"></i> ใช้ตัวกรอง</button>
+            <button class="btn btn-primary"><i class="bi bi-search"></i> Apply filters</button>
           </div>
           <div class="ms-auto col-md-auto d-flex gap-2 align-items-center">
-            <span class="badge bg-primary">บริการที่พบ: <?=number_format($total)?></span>
+            <span class="badge bg-primary">Services found: <?=number_format($total)?></span>
           </div>
         </form>
 
@@ -516,24 +516,24 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
               <tr>
                 <th>ID</th>
                 <th>Service</th>
-                <th>สถานะ</th>
-                <th class="text-center">Option</th>
-                <th class="text-end">ราคาเริ่มต้น</th>
-                <th class="text-end">Total Booking</th>
+                <th>Status</th>
+                <th class="text-center">Options</th>
+                <th class="text-end">Starting price</th>
+                <th class="text-end">Total bookings</th>
               </tr>
             </thead>
             <tbody>
               <?php if(empty($rows)): ?>
-                <tr><td colspan="6" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="6" class="text-center text-muted">No data found</td></tr>
               <?php else: foreach($rows as $r): ?>
                 <tr>
                   <td><?=number_format((int)$r['service_id'])?></td>
                   <td><?=esc($r['service_name'])?></td>
                   <td>
                     <?php if ((int)$r['is_active'] === 1): ?>
-                      <span class="badge bg-success-subtle text-success">เปิดใช้งาน</span>
+                      <span class="badge bg-success-subtle text-success">Active</span>
                     <?php else: ?>
-                      <span class="badge bg-secondary-subtle text-secondary">ปิดใช้งาน</span>
+                      <span class="badge bg-secondary-subtle text-secondary">Inactive</span>
                     <?php endif; ?>
                   </td>
                   <td class="text-center"><?=number_format($r['option_count'])?></td>
@@ -544,7 +544,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             </tbody>
             <tfoot class="table-light">
               <tr>
-                <th colspan="5" class="text-end">รวมการจอง</th>
+                <th colspan="5" class="text-end">Total bookings</th>
                 <th class="text-end"><?=number_format($totalBookingSum)?></th>
               </tr>
             </tfoot>
@@ -553,17 +553,17 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
 
         <?php if($pages > 1): ?>
         <div class="d-flex justify-content-between align-items-center mt-3">
-          <span class="text-muted">หน้า <?=number_format($page)?> / <?=number_format($pages)?></span>
+          <span class="text-muted">Page <?=number_format($page)?> / <?=number_format($pages)?></span>
           <div class="btn-group">
             <?php if($page > 1): ?>
-              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> ก่อนหน้า</a>
+              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> Previous</a>
             <?php else: ?>
-              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> ก่อนหน้า</span>
+              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> Previous</span>
             <?php endif; ?>
             <?php if($page < $pages): ?>
-              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">ถัดไป <i class="bi bi-chevron-right"></i></a>
+              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">Next <i class="bi bi-chevron-right"></i></a>
             <?php else: ?>
-              <span class="btn btn-outline-primary disabled">ถัดไป <i class="bi bi-chevron-right"></i></span>
+              <span class="btn btn-outline-primary disabled">Next <i class="bi bi-chevron-right"></i></span>
             <?php endif; ?>
           </div>
         </div>
@@ -580,7 +580,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
         <div class="row g-3">
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-cash-coin card-icon text-success"></i>
-            <div><div class="kpi-value" id="k_net_total">0</div><div class="text-muted">Net รวม (ยืนยัน)</div></div>
+            <div><div class="kpi-value" id="k_net_total">0</div><div class="text-muted">Net revenue (confirmed)</div></div>
           </div></div></div>
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-cart-check card-icon text-primary"></i>
@@ -592,35 +592,35 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
           </div></div></div>
           <div class="col-md-3"><div class="card"><div class="card-body d-flex align-items-center gap-3">
             <i class="bi bi-stars card-icon text-warning"></i>
-            <div><div class="kpi-value" id="k_services_total">0</div><div class="text-muted">บริการที่ขายแล้ว</div></div>
+            <div><div class="kpi-value" id="k_services_total">0</div><div class="text-muted">Services sold</div></div>
           </div></div></div>
         </div>
         <div class="row g-3 mt-1">
           <div class="col-md-6"><div class="alert alert-light py-2 m-0"><small>Top Service: <b id="k_top_service">-</b> — Net <b id="k_top_service_net">0.00</b></small></div></div>
         </div>
-        <div class="text-muted mb-2">* การ์ดไม่ใช้ตัวกรอง</div>
+        <div class="text-muted mb-2">* Cards ignore the chart filters.</div>
 
         <!-- Chart Filters -->
         <div class="row g-3 align-items-end" id="chartFilters">
           <div class="col-md-auto">
-            <label class="form-label small-label">ช่วงข้อมูล</label>
+            <label class="form-label small-label">Data range</label>
             <select class="form-select" id="chartPeriod">
-              <option value="all">ทั้งหมด</option>
-              <option value="year">ช่วงปี</option>
-              <option value="month">ช่วงเดือน</option>
-              <option value="day">ช่วงวัน</option>
+              <option value="all">All time</option>
+              <option value="year">Year range</option>
+              <option value="month">Month range</option>
+              <option value="day">Day range</option>
             </select>
           </div>
           <div class="col-lg-4 col-md-6 chart-period-control d-none" id="chartPeriodDay">
-            <label class="form-label small-label">เลือกวัน</label>
+            <label class="form-label small-label">Select dates</label>
             <div class="d-flex flex-wrap gap-2">
               <input type="date" class="form-control" id="chartDayStart">
-              <span class="align-self-center small text-muted">ถึง</span>
+              <span class="align-self-center small text-muted">to</span>
               <input type="date" class="form-control" id="chartDayEnd">
             </div>
           </div>
           <div class="col-lg-5 col-md-6 chart-period-control d-none" id="chartPeriodMonth">
-            <label class="form-label small-label">เลือกเดือน</label>
+            <label class="form-label small-label">Select months</label>
             <div class="d-flex flex-wrap gap-2 align-items-center">
               <div class="d-flex gap-2">
                 <select class="form-select" id="chartMonthStart">
@@ -634,7 +634,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
                   <?php endfor; ?>
                 </select>
               </div>
-              <span class="small text-muted">ถึง</span>
+              <span class="small text-muted">to</span>
               <div class="d-flex gap-2">
                 <select class="form-select" id="chartMonthEnd">
                   <?php for($m=1;$m<=12;$m++): ?>
@@ -650,7 +650,7 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             </div>
           </div>
           <div class="col-md-auto chart-period-control d-none" id="chartPeriodYear">
-            <label class="form-label small-label">ช่วงปี</label>
+            <label class="form-label small-label">Year span</label>
             <div class="d-flex gap-2">
               <select class="form-select" id="chartYearStart">
                 <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
@@ -665,14 +665,14 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
             </div>
           </div>
           <div class="col-md-auto">
-            <button id="applyChart" class="btn btn-primary"><i class="bi bi-funnel"></i> ใช้ตัวกรอง</button>
+            <button id="applyChart" class="btn btn-primary"><i class="bi bi-funnel"></i> Apply filters</button>
           </div>
         </div>
 
         <div class="mt-4">
           <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
-            <h6 class="mb-0">เลือกบริการที่ต้องการเปรียบเทียบ</h6>
-            <button class="btn btn-outline-secondary btn-sm" type="button" id="chartSelectAll">เลือกทั้งหมด</button>
+            <h6 class="mb-0">Select services to compare</h6>
+            <button class="btn btn-outline-secondary btn-sm" type="button" id="chartSelectAll">Select all</button>
           </div>
           <div class="mt-2 d-flex flex-wrap gap-2" id="chartServiceCheckboxes"></div>
         </div>
@@ -681,18 +681,18 @@ $tableYearEndVal   = $tablePeriod === 'year' && $tableRangeEnd   ? (int)substr($
         <div class="row mt-4 g-4">
           <div class="col-lg-9">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5 class="mb-0" id="chartDetailTitle">กราฟจำนวนการจองต่อบริการ</h5>
-              <button class="btn btn-sm btn-outline-secondary d-none" type="button" id="chartBackButton"><i class="bi bi-arrow-left"></i> ย้อนกลับ</button>
+              <h5 class="mb-0" id="chartDetailTitle">Bookings per service</h5>
+              <button class="btn btn-sm btn-outline-secondary d-none" type="button" id="chartBackButton"><i class="bi bi-arrow-left"></i> Back</button>
             </div>
             <div class="bg-light rounded p-2" style="min-height:420px">
               <canvas id="svcChart" height="140"></canvas>
             </div>
-            <div class="text-muted mt-2 small">* คลิกแท่งกราฟเพื่อดูรายละเอียดแบบกราฟเส้นของบริการนั้น ๆ</div>
+            <div class="text-muted mt-2 small">* Click a bar to open the line chart for that service.</div>
           </div>
           <div class="col-lg-3">
             <div class="card h-100">
               <div class="card-body">
-                <h6 class="card-title">Top 10 Service</h6>
+                <h6 class="card-title">Top 10 services</h6>
                 <ol class="list-group list-group-numbered" id="topServiceList"></ol>
               </div>
             </div>
@@ -741,8 +741,8 @@ function updateSortDirLabels(){
     ascOpt.textContent = 'A - Z';
     descOpt.textContent = 'Z - A';
   } else {
-    ascOpt.textContent = 'น้อยไปมาก';
-    descOpt.textContent = 'มากไปน้อย';
+    ascOpt.textContent = 'Low to High';
+    descOpt.textContent = 'High to Low';
   }
 }
 sortField?.addEventListener('change', updateSortDirLabels);
@@ -829,7 +829,7 @@ function populateTopList(items){
   if (!items || items.length === 0) {
     const li = document.createElement('li');
     li.className = 'list-group-item text-muted';
-    li.textContent = 'ไม่มีข้อมูล';
+    li.textContent = 'No data available';
     list.appendChild(li);
     return;
   }
@@ -864,7 +864,7 @@ function renderBarChart(){
     data: {
       labels: dataset.map(d => d.service_name),
       datasets: [{
-        label: 'จำนวนการจอง',
+        label: 'Bookings',
         data: dataset.map(d => d.total_booking),
         backgroundColor: 'rgba(13,110,253,0.6)',
         borderColor: '#0d6efd'
@@ -880,7 +880,7 @@ function renderBarChart(){
         legend: { display: false },
         tooltip: {
           callbacks: {
-            label: ctx => `จำนวนการจอง: ${(ctx.parsed.y||0).toLocaleString()}`
+            label: ctx => `Bookings: ${(ctx.parsed.y||0).toLocaleString()}`
           }
         }
       },
@@ -894,7 +894,7 @@ function renderBarChart(){
       }
     }
   });
-  titleEl.textContent = 'กราฟจำนวนการจองต่อบริการ';
+  titleEl.textContent = 'Bookings per service';
 }
 
 async function loadServiceTimeline(serviceId, serviceName){
@@ -909,7 +909,7 @@ async function loadServiceTimeline(serviceId, serviceName){
     data: {
       labels: data.labels || [],
       datasets: [{
-        label: `จำนวนการจอง (${serviceName})`,
+        label: `Bookings (${serviceName})`,
         data: (data.data || []),
         borderColor: '#0d6efd',
         backgroundColor: 'rgba(13,110,253,0.15)',
@@ -929,7 +929,7 @@ async function loadServiceTimeline(serviceId, serviceName){
     }
   });
   document.getElementById('chartBackButton')?.classList.remove('d-none');
-  document.getElementById('chartDetailTitle').textContent = `กราฟบริการ: ${serviceName}`;
+  document.getElementById('chartDetailTitle').textContent = `Service chart: ${serviceName}`;
 }
 
 async function loadChartData(){

--- a/Admin/report_staff.php
+++ b/Admin/report_staff.php
@@ -498,7 +498,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 };
 ?>
 <!doctype html>
-<html lang="th">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Staff Report</title>
@@ -522,12 +522,12 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 <?php include("slidebar.php"); ?>
 <main id="main" class="main">
 
-  <div class="pagetitle"><h1>รายงานสตาฟ (Staff)</h1></div>
+  <div class="pagetitle"><h1>Staff Report</h1></div>
 
   <!-- Tabs -->
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button">ตาราง</button></li>
-    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" id="chart-tab">กราฟ</button></li>
+    <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#t-table" type="button">Table</button></li>
+    <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#t-chart" type="button" id="chart-tab">Chart</button></li>
   </ul>
 
   <div class="tab-content">
@@ -538,40 +538,40 @@ $pageUrl = function(int $target) use ($baseQuery): string {
         <form class="row g-2 align-items-end" method="get" id="staffFilterForm">
           <input type="hidden" name="tab" value="table">
           <div class="col-md-3 col-lg-2">
-            <label class="form-label small-label" for="staffSearch">ค้นหาสตาฟ</label>
-            <input type="text" class="form-control" id="staffSearch" name="q" value="<?=esc($search)?>" placeholder="ชื่อสตาฟ">
+            <label class="form-label small-label" for="staffSearch">Search staff</label>
+            <input type="text" class="form-control" id="staffSearch" name="q" value="<?=esc($search)?>" placeholder="Staff name">
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label" for="serviceFilter">บริการ</label>
+            <label class="form-label small-label" for="serviceFilter">Service</label>
             <select class="form-select" id="serviceFilter" name="service">
-              <option value="0">ทั้งหมด</option>
+              <option value="0">All</option>
               <?php while($sv=$serviceOps->fetch_assoc()): ?>
                 <option value="<?=$sv['service_id']?>" <?= $serviceF==$sv['service_id']?'selected':'' ?>><?=esc($sv['service_name'])?></option>
               <?php endwhile; ?>
             </select>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label" for="date_filter_type">ช่วงเวลา</label>
+            <label class="form-label small-label" for="date_filter_type">Date range</label>
             <select class="form-select" id="date_filter_type" name="date_filter_type">
-              <option value="range" <?= $filterType==='range'?'selected':'' ?>>ช่วงวันที่</option>
-              <option value="month" <?= $filterType==='month'?'selected':'' ?>>เดือน</option>
-              <option value="year" <?= $filterType==='year'?'selected':'' ?>>ปี</option>
-              <option value="all" <?= $filterType==='all'?'selected':'' ?>>ทั้งหมด</option>
+              <option value="range" <?= $filterType==='range'?'selected':'' ?>>Custom range</option>
+              <option value="month" <?= $filterType==='month'?'selected':'' ?>>Month</option>
+              <option value="year" <?= $filterType==='year'?'selected':'' ?>>Year</option>
+              <option value="all" <?= $filterType==='all'?'selected':'' ?>>All time</option>
             </select>
           </div>
           <div class="col-md-auto <?= $filterType==='range'?'':'d-none' ?>" id="date_range_group">
-            <label class="form-label small-label">วันที่</label>
+            <label class="form-label small-label">Dates</label>
             <div class="d-flex gap-2">
               <input type="date" class="form-control" name="start_date" value="<?=esc($filterType==='range'?$startDate:'')?>">
               <input type="date" class="form-control" name="end_date"   value="<?=esc($filterType==='range'?$endDate:'')?>">
             </div>
           </div>
           <div class="col-md-auto <?= $filterType==='month'?'':'d-none' ?>" id="month_group">
-            <label class="form-label small-label" for="month_value">เดือน</label>
+            <label class="form-label small-label" for="month_value">Month</label>
             <input type="month" class="form-control" id="month_value" name="month_value" value="<?=esc($filterType==='month'?$monthValue:'')?>">
           </div>
           <div class="col-md-auto <?= $filterType==='year'?'':'d-none' ?>" id="year_group">
-            <label class="form-label small-label">ปี</label>
+            <label class="form-label small-label">Years</label>
             <div class="d-flex gap-2">
               <select class="form-select" name="start_year" id="start_year">
                 <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
@@ -586,13 +586,13 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </div>
           </div>
           <div class="col-md-auto">
-            <label class="form-label small-label" for="sort_field">เรียงตาม</label>
+            <label class="form-label small-label" for="sort_field">Sort by</label>
             <div class="input-group">
               <select class="form-select" id="sort_field" name="sort">
-                <option value="name" <?= $sort==='name'?'selected':'' ?>>ชื่อ</option>
-                <option value="popularity" <?= $sort==='popularity'?'selected':'' ?>>ความนิยม</option>
-                <option value="hours" <?= $sort==='hours'?'selected':'' ?>>จำนวนชั่วโมง</option>
-                <option value="revenue" <?= $sort==='revenue'?'selected':'' ?>>รายได้</option>
+                <option value="name" <?= $sort==='name'?'selected':'' ?>>Name</option>
+                <option value="popularity" <?= $sort==='popularity'?'selected':'' ?>>Bookings</option>
+                <option value="hours" <?= $sort==='hours'?'selected':'' ?>>Hours</option>
+                <option value="revenue" <?= $sort==='revenue'?'selected':'' ?>>Revenue</option>
               </select>
               <select class="form-select" id="sort_dir" name="dir">
                 <option value="ASC"  <?= $dir==='ASC'?'selected':'' ?>>A → Z</option>
@@ -601,13 +601,13 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </div>
           </div>
           <div class="col-md-auto">
-            <button class="btn btn-primary" type="submit"><i class="bi bi-funnel"></i> ใช้ตัวกรอง</button>
+            <button class="btn btn-primary" type="submit"><i class="bi bi-funnel"></i> Apply filters</button>
           </div>
         </form>
 
         <div class="d-flex flex-wrap gap-2 align-items-center mt-3">
-          <span class="badge bg-secondary">พนักงาน Active ทั้งหมด: <?=number_format($activeStaffTotal)?> คน</span>
-          <span class="badge bg-primary">ผลลัพธ์จากตัวกรอง: <?=number_format($filteredCount)?> คน</span>
+          <span class="badge bg-secondary">Active staff: <?=number_format($activeStaffTotal)?></span>
+          <span class="badge bg-primary">Matched by filters: <?=number_format($filteredCount)?></span>
         </div>
 
         <div class="table-responsive mt-3">
@@ -617,7 +617,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
                 <th>Staff</th>
                 <th class="text-end">Bookings</th>
                 <th class="text-end">Confirmed</th>
-                <th class="text-end">Complate</th>
+                <th class="text-end">Completed</th>
                 <th class="text-end">Pending</th>
                 <th class="text-end">Cancelled</th>
                 <th class="text-end">Net Revenue</th>
@@ -632,7 +632,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </thead>
             <tbody>
               <?php if (empty($rows)): ?>
-                <tr><td colspan="13" class="text-center text-muted">ไม่พบข้อมูล</td></tr>
+                <tr><td colspan="13" class="text-center text-muted">No data found</td></tr>
               <?php else:
                 foreach($rows as $r):
                   $hrs = (float)($r['hrs'] ?? 0);
@@ -672,7 +672,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </tbody>
                         <!-- <tfoot class="table-light">
               <tr>
-                <th>รวม</th>
+                <th>Total</th>
                 <th class="text-end fw-bold"><?=number_format($summary['tx_total'])?></th>
                 <th class="text-end"><span class="badge bg-success"><?=number_format($summary['tx_conf'])?></span></th>
                 <th class="text-end"><span class="badge bg-primary"><?=number_format($summary['tx_comp'])?></span></th>
@@ -693,17 +693,17 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 
         <?php if($pages > 1): ?>
         <div class="d-flex justify-content-between align-items-center mt-3">
-          <span class="text-muted">หน้า <?=number_format($page)?> / <?=number_format($pages)?></span>
+          <span class="text-muted">Page <?=number_format($page)?> / <?=number_format($pages)?></span>
           <div class="btn-group">
             <?php if($page > 1): ?>
-              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> ก่อนหน้า</a>
+              <a class="btn btn-outline-secondary" href="<?=esc($pageUrl($page-1))?>"><i class="bi bi-chevron-left"></i> Previous</a>
             <?php else: ?>
-              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> ก่อนหน้า</span>
+              <span class="btn btn-outline-secondary disabled"><i class="bi bi-chevron-left"></i> Previous</span>
             <?php endif; ?>
             <?php if($page < $pages): ?>
-              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">ถัดไป <i class="bi bi-chevron-right"></i></a>
+              <a class="btn btn-outline-primary" href="<?=esc($pageUrl($page+1))?>">Next <i class="bi bi-chevron-right"></i></a>
             <?php else: ?>
-              <span class="btn btn-outline-primary disabled">ถัดไป <i class="bi bi-chevron-right"></i></span>
+              <span class="btn btn-outline-primary disabled">Next <i class="bi bi-chevron-right"></i></span>
             <?php endif; ?>
           </div>
         </div>
@@ -716,19 +716,19 @@ $pageUrl = function(int $target) use ($baseQuery): string {
       <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 class="modal-title" id="bookingStatusTitle">รายการจอง</h5>
+            <h5 class="modal-title" id="bookingStatusTitle">Bookings</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
           <div class="modal-body">
             <div class="table-responsive">
               <table class="table table-sm align-middle">
-                <thead><tr><th>รหัส</th><th>ลูกค้า</th><th>บริการ</th><th>วันที่</th><th>เวลา</th><th class="text-end">ราคา</th></tr></thead>
-                <tbody id="bookingStatusBody"><tr><td colspan="6" class="text-center text-muted">กำลังโหลด...</td></tr></tbody>
+                <thead><tr><th>ID</th><th>Customer</th><th>Services</th><th>Date</th><th>Time</th><th class="text-end">Price</th></tr></thead>
+                <tbody id="bookingStatusBody"><tr><td colspan="6" class="text-center text-muted">Loading...</td></tr></tbody>
               </table>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ปิด</button>
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           </div>
         </div>
       </div>
@@ -740,16 +740,16 @@ $pageUrl = function(int $target) use ($baseQuery): string {
 
         <div class="row g-3 align-items-end">
           <div class="col-md-3 col-lg-2">
-            <label class="form-label small-label" for="chart_period">ช่วงเวลา</label>
+            <label class="form-label small-label" for="chart_period">Period</label>
             <select class="form-select" id="chart_period">
-              <option value="all">ทั้งหมด</option>
-              <option value="year">ช่วงปี</option>
-              <option value="month">ช่วงเดือน</option>
-              <option value="day">ช่วงวัน</option>
+              <option value="all">All time</option>
+              <option value="year">Year range</option>
+              <option value="month">Month range</option>
+              <option value="day">Day range</option>
             </select>
           </div>
           <div class="col-md-auto d-none" id="chart_year_group">
-            <label class="form-label small-label">ปี (จาก-ถึง)</label>
+            <label class="form-label small-label">Years (from - to)</label>
             <div class="d-flex gap-2">
               <select class="form-select" id="chart_start_year">
                 <?php for($y=$minYear;$y<=$maxYear;$y++): ?>
@@ -764,21 +764,21 @@ $pageUrl = function(int $target) use ($baseQuery): string {
             </div>
           </div>
           <div class="col-md-auto d-none" id="chart_month_group">
-            <label class="form-label small-label">เดือน (จาก-ถึง)</label>
+            <label class="form-label small-label">Months (from - to)</label>
             <div class="d-flex gap-2">
               <input type="month" class="form-control" id="chart_start_month" value="<?=date('Y-m')?>">
               <input type="month" class="form-control" id="chart_end_month" value="<?=date('Y-m')?>">
             </div>
           </div>
           <div class="col-md-auto d-none" id="chart_day_group">
-            <label class="form-label small-label">วันที่ (จาก-ถึง)</label>
+            <label class="form-label small-label">Dates (from - to)</label>
             <div class="d-flex gap-2">
               <input type="date" class="form-control" id="chart_start_day" value="<?=date('Y-m-01')?>">
               <input type="date" class="form-control" id="chart_end_day" value="<?=date('Y-m-d')?>">
             </div>
           </div>
           <div class="col-md-auto">
-            <button class="btn btn-primary" id="chartApply"><i class="bi bi-funnel"></i> ใช้ตัวกรอง</button>
+            <button class="btn btn-primary" id="chartApply"><i class="bi bi-funnel"></i> Apply filters</button>
           </div>
         </div>
 
@@ -786,18 +786,18 @@ $pageUrl = function(int $target) use ($baseQuery): string {
           <div class="col-lg-8">
             <div class="card h-100"><div class="card-body">
               <div class="d-flex justify-content-between align-items-center mb-2">
-                <h6 class="card-title mb-0" id="chartTitle">ภาพรวมจำนวนการจองของสตาฟ</h6>
-                <button class="btn btn-sm btn-outline-secondary d-none" id="chartBack"><i class="bi bi-arrow-left"></i> กลับ</button>
+                <h6 class="card-title mb-0" id="chartTitle">Staff booking volume overview</h6>
+                <button class="btn btn-sm btn-outline-secondary d-none" id="chartBack"><i class="bi bi-arrow-left"></i> Back</button>
               </div>
               <div class="chart-wrapper">
                 <canvas id="staffMainChart"></canvas>
               </div>
               <div class="mt-3">
                 <div class="d-flex align-items-center gap-2 mb-2">
-                  <strong>เลือกพนักงาน</strong>
-                  <button class="btn btn-sm btn-outline-dark" id="toggleStaffList" type="button">เลือกบางคน</button>
-                  <button class="btn btn-sm btn-outline-primary" id="selectAllStaff" type="button">เลือกทั้งหมด</button>
-                  <button class="btn btn-sm btn-outline-secondary" id="clearAllStaff" type="button">ล้างทั้งหมด</button>
+                  <strong>Select staff</strong>
+                  <button class="btn btn-sm btn-outline-dark" id="toggleStaffList" type="button">Choose specific staff</button>
+                  <button class="btn btn-sm btn-outline-primary" id="selectAllStaff" type="button">Select all</button>
+                  <button class="btn btn-sm btn-outline-secondary" id="clearAllStaff" type="button">Clear all</button>
                 </div>
                 <div id="staffCheckboxes" class="d-flex flex-wrap gap-2 d-none"></div>
               </div>
@@ -811,7 +811,7 @@ $pageUrl = function(int $target) use ($baseQuery): string {
           </div>
         </div>
 
-        <p class="text-muted mt-3" id="chartHint">* คลิกแท่งกราฟของพนักงานเพื่อดูรายละเอียดแบบกราฟเส้น และกดปุ่ม "กลับ" เพื่อย้อนกลับ</p>
+        <p class="text-muted mt-3" id="chartHint">* Click a staff bar to view the line chart details, then press "Back" to return.</p>
 
       </div></div>
     </div>
@@ -848,8 +848,8 @@ function updateSortLabels() {
     asc.textContent = 'A → Z';
     desc.textContent = 'Z → A';
   } else {
-    asc.textContent = 'น้อย → มาก';
-    desc.textContent = 'มาก → น้อย';
+    asc.textContent = 'Low → High';
+    desc.textContent = 'High → Low';
   }
 }
 updateSortLabels();
@@ -868,9 +868,9 @@ if (searchInput && filterForm) {
 }
 
 const statusNames = {
-  total: 'ทั้งหมด',
+  total: 'All',
   confirmed: 'Confirmed',
-  completed: 'Complate',
+  completed: 'Completed',
   pending: 'Pending',
   cancelled: 'Cancelled'
 };
@@ -886,7 +886,7 @@ function formatCurrency(amount) {
 async function fetchStaffBookings(staffId, statusKey, staffName) {
   if (!bookingBody || !bookingTitle) return;
   bookingTitle.textContent = `${staffName} - ${statusNames[statusKey] || ''}`;
-  bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">กำลังโหลด...</td></tr>';
+  bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">Loading...</td></tr>';
   if (bookingModal) bookingModal.show();
 
   const url = new URL(location.href);
@@ -905,7 +905,7 @@ async function fetchStaffBookings(staffId, statusKey, staffName) {
     const data = await res.json();
     const bookings = data.bookings || [];
     if (!bookings.length) {
-      bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">ไม่พบข้อมูล</td></tr>';
+      bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-muted">No data found</td></tr>';
       return;
     }
     bookingBody.innerHTML = '';
@@ -924,7 +924,7 @@ async function fetchStaffBookings(staffId, statusKey, staffName) {
     });
   } catch (err) {
     console.error(err);
-    bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-danger">เกิดข้อผิดพลาดในการดึงข้อมูล</td></tr>';
+    bookingBody.innerHTML = '<tr><td colspan="6" class="text-center text-danger">Unable to fetch data</td></tr>';
   }
 }
 
@@ -967,7 +967,7 @@ function setStaffListVisible(visible) {
     staffCheckboxesEl.classList.toggle('d-none', !staffListVisible);
   }
   if (toggleStaffListBtn) {
-    toggleStaffListBtn.textContent = staffListVisible ? 'ซ่อนรายชื่อ' : 'เลือกบางคน';
+    toggleStaffListBtn.textContent = staffListVisible ? 'Hide list' : 'Choose specific staff';
   }
 }
 
@@ -1021,7 +1021,7 @@ function renderTopList(items) {
   if (!items || !items.length) {
     const li = document.createElement('li');
     li.className = 'list-group-item text-muted';
-    li.textContent = 'ไม่มีข้อมูล';
+    li.textContent = 'No data available';
     topStaffListEl.appendChild(li);
     return;
   }
@@ -1029,7 +1029,7 @@ function renderTopList(items) {
     const li = document.createElement('li');
     li.className = 'list-group-item d-flex justify-content-between align-items-center';
     const total = Number(item.total || 0).toLocaleString();
-    li.innerHTML = `<span>${item.name || '-'}</span><span class="badge bg-primary rounded-pill">${total} ครั้ง</span>`;
+    li.innerHTML = `<span>${item.name || '-'}</span><span class="badge bg-primary rounded-pill">${total} times</span>`;
     topStaffListEl.appendChild(li);
   });
 }
@@ -1038,7 +1038,7 @@ function renderStaffCheckboxes() {
   if (!staffCheckboxesEl) return;
   staffCheckboxesEl.innerHTML = '';
   if (!overviewData.length) {
-    staffCheckboxesEl.innerHTML = '<span class="text-muted">ไม่มีข้อมูล</span>';
+    staffCheckboxesEl.innerHTML = '<span class="text-muted">No staff available</span>';
     return;
   }
   overviewData.forEach((staff) => {
@@ -1062,7 +1062,7 @@ function renderStaffCheckboxes() {
       detailMode = false;
       currentDetail = null;
       chartBackBtn?.classList.add('d-none');
-      chartTitleEl.textContent = 'ภาพรวมจำนวนการจองของสตาฟ';
+      chartTitleEl.textContent = 'Staff booking volume overview';
       renderOverviewChart();
     });
   });
@@ -1082,7 +1082,7 @@ function renderOverviewChart() {
     staffList = overviewData.filter((staff) => selectedStaffIds.has(staff.id));
   }
   if (!staffList.length) {
-    if (chartHintEl) chartHintEl.textContent = 'กรุณาเลือกพนักงานเพื่อแสดงข้อมูล';
+    if (chartHintEl) chartHintEl.textContent = 'Please select staff to display data.';
     return;
   }
   const labels = staffList.map((s) => s.name);
@@ -1098,9 +1098,9 @@ function renderOverviewChart() {
     data: {
       labels,
       datasets: [
-        {label: 'ทั้งหมด', data: staffList.map(s => Number(s.total || 0)), backgroundColor: palette.total},
+        {label: 'All', data: staffList.map(s => Number(s.total || 0)), backgroundColor: palette.total},
         {label: 'Confirmed', data: staffList.map(s => Number(s.confirmed || 0)), backgroundColor: palette.confirmed},
-        {label: 'Complate', data: staffList.map(s => Number(s.completed || 0)), backgroundColor: palette.completed},
+        {label: 'Completed', data: staffList.map(s => Number(s.completed || 0)), backgroundColor: palette.completed},
         {label: 'Pending', data: staffList.map(s => Number(s.pending || 0)), backgroundColor: palette.pending},
         {label: 'Cancelled', data: staffList.map(s => Number(s.cancelled || 0)), backgroundColor: palette.cancelled}
       ]
@@ -1122,7 +1122,7 @@ function renderOverviewChart() {
     }
   });
   if (chartHintEl) {
-    chartHintEl.textContent = '* คลิกแท่งกราฟของพนักงานเพื่อดูรายละเอียดแบบกราฟเส้น และกดปุ่ม "กลับ" เพื่อย้อนกลับ';
+    chartHintEl.textContent = '* Click a staff bar to view the line chart details, then press "Back" to return.';
   }
 }
 
@@ -1135,12 +1135,12 @@ async function loadOverview() {
     detailMode = false;
     currentDetail = null;
     chartBackBtn?.classList.add('d-none');
-    chartTitleEl.textContent = 'ภาพรวมจำนวนการจองของสตาฟ';
+    chartTitleEl.textContent = 'Staff booking volume overview';
     if (!overviewData.length) {
       selectedStaffIds.clear();
       setStaffListVisible(false);
       renderStaffCheckboxes();
-      if (chartHintEl) chartHintEl.textContent = 'ไม่มีข้อมูลพนักงาน';
+      if (chartHintEl) chartHintEl.textContent = 'No staff data available.';
       if (staffChart) { staffChart.destroy(); staffChart = null; }
       renderTopList([]);
       return;
@@ -1152,7 +1152,7 @@ async function loadOverview() {
     renderTopList(data.top || []);
   } catch (err) {
     console.error(err);
-    if (chartHintEl) chartHintEl.textContent = 'ไม่สามารถโหลดข้อมูลกราฟได้';
+    if (chartHintEl) chartHintEl.textContent = 'Unable to load chart data.';
   }
 }
 
@@ -1180,9 +1180,9 @@ async function loadDetail(staffId, staffName) {
       data: {
         labels,
         datasets: [
-          {label: 'ทั้งหมด', data: (series.total || []).map(v => Number(v || 0)), borderColor: palette.total, backgroundColor: palette.total, fill: false, tension: 0.3, pointRadius: 3},
+          {label: 'All', data: (series.total || []).map(v => Number(v || 0)), borderColor: palette.total, backgroundColor: palette.total, fill: false, tension: 0.3, pointRadius: 3},
           {label: 'Confirmed', data: (series.confirmed || []).map(v => Number(v || 0)), borderColor: palette.confirmed, backgroundColor: palette.confirmed, fill: false, tension: 0.3, pointRadius: 3},
-          {label: 'Complate', data: (series.completed || []).map(v => Number(v || 0)), borderColor: palette.completed, backgroundColor: palette.completed, fill: false, tension: 0.3, pointRadius: 3},
+          {label: 'Completed', data: (series.completed || []).map(v => Number(v || 0)), borderColor: palette.completed, backgroundColor: palette.completed, fill: false, tension: 0.3, pointRadius: 3},
           {label: 'Pending', data: (series.pending || []).map(v => Number(v || 0)), borderColor: palette.pending, backgroundColor: palette.pending, fill: false, tension: 0.3, pointRadius: 3},
           {label: 'Cancelled', data: (series.cancelled || []).map(v => Number(v || 0)), borderColor: palette.cancelled, backgroundColor: palette.cancelled, fill: false, tension: 0.3, pointRadius: 3}
         ]
@@ -1200,8 +1200,8 @@ async function loadDetail(staffId, staffName) {
     detailMode = true;
     currentDetail = {staffId, staffName};
     chartBackBtn?.classList.remove('d-none');
-    chartTitleEl.textContent = `รายละเอียดของ ${staffName}`;
-    if (chartHintEl) chartHintEl.textContent = 'กำลังแสดงกราฟเส้นของพนักงานที่เลือก';
+    chartTitleEl.textContent = `Details for ${staffName}`;
+    if (chartHintEl) chartHintEl.textContent = 'Displaying the selected staff line chart.';
   } catch (err) {
     console.error(err);
   }
@@ -1216,7 +1216,7 @@ chartBackBtn?.addEventListener('click', () => {
   detailMode = false;
   currentDetail = null;
   chartBackBtn.classList.add('d-none');
-  chartTitleEl.textContent = 'ภาพรวมจำนวนการจองของสตาฟ';
+  chartTitleEl.textContent = 'Staff booking volume overview';
   renderOverviewChart();
 });
 
@@ -1225,7 +1225,7 @@ selectAllBtn?.addEventListener('click', () => {
   detailMode = false;
   currentDetail = null;
   chartBackBtn?.classList.add('d-none');
-  chartTitleEl.textContent = 'ภาพรวมจำนวนการจองของสตาฟ';
+  chartTitleEl.textContent = 'Staff booking volume overview';
   setStaffListVisible(false);
   renderStaffCheckboxes();
   renderOverviewChart();
@@ -1236,10 +1236,10 @@ clearAllBtn?.addEventListener('click', () => {
   detailMode = false;
   currentDetail = null;
   chartBackBtn?.classList.add('d-none');
-  chartTitleEl.textContent = 'ภาพรวมจำนวนการจองของสตาฟ';
+  chartTitleEl.textContent = 'Staff booking volume overview';
   setStaffListVisible(true);
   renderStaffCheckboxes();
-  if (chartHintEl) chartHintEl.textContent = 'กรุณาเลือกพนักงานเพื่อแสดงข้อมูล';
+  if (chartHintEl) chartHintEl.textContent = 'Please select staff to display data.';
   if (staffChart) {
     staffChart.destroy();
     staffChart = null;

--- a/Admin/table_promotion.php
+++ b/Admin/table_promotion.php
@@ -35,7 +35,7 @@ $result = $conn->query($sql);
   <main id="main" class="main">
 
     <div class="pagetitle">
-      <h1>จัดการโปรโมชั่น</h1>
+      <h1>Manage Promotions</h1>
     </div>
 
     <section class="section">
@@ -46,7 +46,7 @@ $result = $conn->query($sql);
             <div class="card-body pt-4">
 
               <div class="text-end mb-3">
-                <a href="form_promotion.php" class="btn btn-success"><i class="bi bi-plus"></i> เพิ่มโปรโมชั่น</a>
+                <a href="form_promotion.php" class="btn btn-success"><i class="bi bi-plus"></i> Add Promotion</a>
               </div>
 
               <?php if (!empty($message)): ?>
@@ -68,13 +68,13 @@ $result = $conn->query($sql);
                   <thead class="table-light">
                     <tr>
                       <th scope="col">#</th>
-                      <th scope="col">ชื่อโปรโมชั่น</th>
-                      <th scope="col">วัน-เวลาเริ่มต้น</th>
-                      <th scope="col">วัน-เวลาสิ้นสุด</th>
-                      <th scope="col">สถานะ</th>
-                      <th scope="col" class="text-end">บริการที่เข้าร่วม</th>
-                      <th scope="col" class="text-end">ส่วนลดสูงสุด (%)</th>
-                      <th scope="col" class="text-center">การจัดการ</th>
+                      <th scope="col">Promotion Name</th>
+                      <th scope="col">Start Date &amp; Time</th>
+                      <th scope="col">End Date &amp; Time</th>
+                      <th scope="col">Status</th>
+                      <th scope="col" class="text-end">Participating Services</th>
+                      <th scope="col" class="text-end">Maximum Discount (%)</th>
+                      <th scope="col" class="text-center">Actions</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -116,38 +116,38 @@ $result = $conn->query($sql);
                               <a
                                 href="promotion_detail.php?id=<?= $promotionId ?>"
                                 class="btn btn-outline-primary btn-sm"
-                                title="รายละเอียด"
-                                aria-label="รายละเอียด"
+                                title="Details"
+                                aria-label="Details"
                               >
                                 <i class="bi bi-eye"></i>
-                                <span class="visually-hidden">รายละเอียด</span>
+                                <span class="visually-hidden">Details</span>
                               </a>
                               <?php if ($status !== 'ended'): ?>
                                 <a
                                   href="promotion_update_form.php?id=<?= $promotionId ?>"
                                   class="btn btn-outline-secondary btn-sm"
-                                  title="แก้ไข"
-                                  aria-label="แก้ไข"
+                                  title="Edit"
+                                  aria-label="Edit"
                                 >
                                   <i class="bi bi-pencil-square"></i>
-                                  <span class="visually-hidden">แก้ไข</span>
+                                  <span class="visually-hidden">Edit</span>
                                 </a>
                               <?php endif; ?>
 
                               <?php if ($status === 'upcoming'): ?>
-                                <form action="promotion_delete.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการลบโปรโมชั่นนี้หรือไม่?');">
+                                <form action="promotion_delete.php" method="post" class="d-inline" onsubmit="return confirm('Do you want to delete this promotion?');">
                                   <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
-                                  <button type="submit" class="btn btn-outline-danger btn-sm" title="ลบ" aria-label="ลบ">
+                                  <button type="submit" class="btn btn-outline-danger btn-sm" title="Delete" aria-label="Delete">
                                     <i class="bi bi-trash"></i>
-                                    <span class="visually-hidden">ลบ</span>
+                                    <span class="visually-hidden">Delete</span>
                                   </button>
                                 </form>
                               <?php elseif ($status === 'running'): ?>
-                                <form action="promotion_end.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการสิ้นสุดโปรโมชั่นนี้ทันทีหรือไม่?');">
+                                <form action="promotion_end.php" method="post" class="d-inline" onsubmit="return confirm('Do you want to end this promotion immediately?');">
                                   <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
-                                  <button type="submit" class="btn btn-outline-warning btn-sm" title="สิ้นสุดทันที" aria-label="สิ้นสุดทันที">
+                                  <button type="submit" class="btn btn-outline-warning btn-sm" title="End Now" aria-label="End Now">
                                     <i class="bi bi-stop-circle"></i>
-                                    <span class="visually-hidden">สิ้นสุดทันที</span>
+                                    <span class="visually-hidden">End Now</span>
                                   </button>
                                 </form>
                               <?php else: ?>
@@ -159,7 +159,7 @@ $result = $conn->query($sql);
                       <?php endwhile; ?>
                     <?php else: ?>
                       <tr>
-                        <td colspan="8" class="text-center text-muted">ยังไม่มีข้อมูลโปรโมชั่น</td>
+                        <td colspan="8" class="text-center text-muted">No promotions found</td>
                       </tr>
                     <?php endif; ?>
                   </tbody>


### PR DESCRIPTION
## Summary
- translate the promotion table page UI, headings, and action labels into English
- update promotion status helper labels to return English text for reuse across the admin area

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5fe1321b0832da121cc3514d5c6f8