### PR TITLE
Translate promotion management page to English

### DIFF
--- a/Admin/form_promotion.php
+++ b/Admin/form_promotion.php
@@ -16,7 +16,7 @@ $defaultEnd = (new DateTimeImmutable('now +1 day'))->format('Y-m-d\TH:i');
 
   <main id="main" class="main">
     <div class="pagetitle">
-      <h1>เพิ่มโปรโมชั่น</h1>
+      <h1>Add Promotion</h1>
     </div>
 
     <section class="section">
@@ -28,26 +28,26 @@ $defaultEnd = (new DateTimeImmutable('now +1 day'))->format('Y-m-d\TH:i');
               <form id="promotionForm" data-promotion-form method="post" action="insert_promotion.php">
                 <div class="row g-3">
                   <div class="col-md-6">
-                    <label class="form-label">ชื่อโปรโมชั่น</label>
-                    <input type="text" name="pm_name" class="form-control" placeholder="ระบุชื่อโปรโมชั่น" required>
+                    <label class="form-label">Promotion Name</label>
+                    <input type="text" name="pm_name" class="form-control" placeholder="Enter promotion name" required>
                   </div>
                   <div class="col-md-3">
-                    <label class="form-label">วัน-เวลาเริ่มต้น</label>
+                    <label class="form-label">Start Date &amp; Time</label>
                     <input type="datetime-local" name="pm_start_date" class="form-control" value="<?= htmlspecialchars($defaultStart) ?>" required>
                   </div>
                   <div class="col-md-3">
-                    <label class="form-label">วัน-เวลาสิ้นสุด</label>
+                    <label class="form-label">End Date &amp; Time</label>
                     <input type="datetime-local" name="pm_end_date" class="form-control" value="<?= htmlspecialchars($defaultEnd) ?>" required>
                   </div>
                 </div>
 
                 <div class="mt-4 d-flex justify-content-between align-items-center">
-                  <h5 class="mb-0">บริการที่เข้าร่วมโปรโมชั่น</h5>
-                  <button type="button" class="btn btn-primary" data-add-service><i class="bi bi-plus-lg"></i> เพิ่มบริการ</button>
+                  <h5 class="mb-0">Services in Promotion</h5>
+                  <button type="button" class="btn btn-primary" data-add-service><i class="bi bi-plus-lg"></i> Add Service</button>
                 </div>
 
                 <div class="alert alert-info mt-3" data-empty-state>
-                  กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุด จากนั้นคลิกปุ่ม "เพิ่มบริการ" เพื่อเลือกบริการที่ต้องการจัดโปรโมชั่น
+                  Please enter the start and end date/time, then click the "Add Service" button to choose services for the promotion.
                 </div>
 
                 <div class="row mt-3" data-selected-services></div>
@@ -55,8 +55,8 @@ $defaultEnd = (new DateTimeImmutable('now +1 day'))->format('Y-m-d\TH:i');
                 <input type="hidden" name="promotion_payload" data-payload>
 
                 <div class="mt-4 text-center">
-                  <button type="submit" class="btn btn-success">บันทึกโปรโมชั่น</button>
-                  <a href="table_promotion.php" class="btn btn-secondary">ยกเลิก</a>
+                  <button type="submit" class="btn btn-success">Save Promotion</button>
+                  <a href="table_promotion.php" class="btn btn-secondary">Cancel</a>
                 </div>
               </form>
 
@@ -72,25 +72,25 @@ $defaultEnd = (new DateTimeImmutable('now +1 day'))->format('Y-m-d\TH:i');
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="serviceSelectModalLabel">เลือกบริการเข้าร่วมโปรโมชั่น</h5>
+          <h5 class="modal-title" id="serviceSelectModalLabel">Select Services for Promotion</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <div class="alert alert-warning d-none" data-modal-warning>
-            กรุณากรอกวัน-เวลาเริ่มต้นและสิ้นสุดของโปรโมชั่นก่อนเลือกบริการ
+            Please provide the promotion start and end date before selecting services.
           </div>
           <div class="form-check mb-3">
             <input class="form-check-input" type="checkbox" id="selectAllServices" data-select-all>
-            <label class="form-check-label" for="selectAllServices">เลือกทั้งหมด</label>
+            <label class="form-check-label" for="selectAllServices">Select All</label>
           </div>
           <div class="list-group" data-service-checkboxes></div>
           <div class="text-muted mt-3 d-none" data-no-service>
-            ไม่พบบริการที่สามารถจัดโปรโมชั่นได้ในช่วงเวลานี้
+            No services are available for this time range.
           </div>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">ยกเลิก</button>
-          <button type="button" class="btn btn-primary" data-confirm-services>ยืนยัน</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" data-confirm-services>Confirm</button>
         </div>
       </div>
     </div>

--- a/Admin/index.php
+++ b/Admin/index.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 
-// ถ้ายังไม่ได้ล็อกอิน
+// Redirect to login page when the staff member is not authenticated
 if (!isset($_SESSION['staff_id'])) {
     header("Location: loginadmin.php");
     exit;
@@ -150,7 +150,7 @@ for ($i = 6; $i >= 0; $i--) {
 ?>
 
 <!DOCTYPE html>
-<html lang="th">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -215,7 +215,7 @@ for ($i = 6; $i >= 0; $i--) {
             <!-- Main content -->
             <!-- <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4"> -->
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-                    <h1 class="h2">แดชบอร์ด</h1>
+                    <h1 class="h2">Dashboard</h1>
                     <div class="btn-toolbar mb-2 mb-md-0">
                         <div class="btn-group me-2">
                             <a href="?period=today" class="btn btn-sm btn-outline-secondary <?= $period == 'today' ? 'active' : '' ?>">Today</a>
@@ -233,7 +233,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">การจอง</div>
+                                        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Bookings</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800"><?= $kpiData['total_bookings'] ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -249,7 +249,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">รายได้สุทธิ</div>
+                                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Net Revenue</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800">฿<?= number_format($kpiData['net_revenue'], 2) ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -265,7 +265,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-info text-uppercase mb-1">ลูกค้าทั้งหมด</div>
+                                        <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Total Customers</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800"><?= $kpiData['total_customers'] ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -281,7 +281,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">บริการที่เปิดใช้งาน</div>
+                                        <div class="text-xs font-weight-bold text-warning text-uppercase mb-1">Active Services</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800"><?= $kpiData['active_services'] ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -300,7 +300,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-secondary text-uppercase mb-1">พนักงาน Active</div>
+                                        <div class="text-xs font-weight-bold text-secondary text-uppercase mb-1">Active Staff</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800"><?= $kpiData['active_staff'] ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -317,7 +317,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">อัตราการยกเลิก</div>
+                                        <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">Cancellation Rate</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800"><?= $kpiData['cancellation_rate'] ?>%</div>
                                     </div>
                                     <div class="col-auto">
@@ -333,7 +333,7 @@ for ($i = 6; $i >= 0; $i--) {
                             <div class="card-body">
                                 <div class="row no-gutters align-items-center">
                                     <div class="col mr-2">
-                                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">ส่วนลดรวม</div>
+                                        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Total Discount</div>
                                         <div class="h5 mb-0 font-weight-bold text-gray-800">฿<?= number_format($kpiData['total_discount'], 2) ?></div>
                                     </div>
                                     <div class="col-auto">
@@ -351,7 +351,7 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-8">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-graph-up me-2"></i>แนวโน้มรายได้ (7 วันล่าสุด)</h5>
+                                <h5><i class="bi bi-graph-up me-2"></i>Revenue Trend (Last 7 Days)</h5>
                             </div>
                             <div class="card-body">
                                 <div class="chart-container">
@@ -365,7 +365,7 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-pie-chart me-2"></i>บริการยอดนิยม</h5>
+                                <h5><i class="bi bi-pie-chart me-2"></i>Top Services</h5>
                             </div>
                             <div class="card-body">
                                 <div class="chart-container">
@@ -382,23 +382,23 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-12">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-list-ul me-2"></i>การจองล่าสุด</h5>
+                                <h5><i class="bi bi-list-ul me-2"></i>Recent Bookings</h5>
                             </div>
                             <div class="card-body">
                                 <div class="table-responsive">
                                     <table class="table table-striped table-hover">
                                         <thead>
                                             <tr>
-                                                <th>รหัสจอง</th>
-                                                <th>ลูกค้า</th>
-                                                <th>พนักงาน</th>
-                                                <th>วันที่จอง</th>
-                                                <th>เวลา</th>
-                                                <th>บริการ</th>
-                                                <th>ราคารวม</th>
-                                                <th>ส่วนลด</th>
-                                                <th>สุทธิ</th>
-                                                <th>สถานะ</th>
+                                                <th>Booking ID</th>
+                                                <th>Customer</th>
+                                                <th>Staff</th>
+                                                <th>Booking Date</th>
+                                                <th>Time</th>
+                                                <th>Services</th>
+                                                <th>Total Price</th>
+                                                <th>Discount</th>
+                                                <th>Net</th>
+                                                <th>Status</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -421,10 +421,10 @@ for ($i = 6; $i >= 0; $i--) {
                                                     <?php
                                                     $statusCode = booking_status_code($booking['status']);
                                                     $statusTexts = [
-                                                        BOOKING_STATUS_CONFIRMED => 'ยืนยันแล้ว',
-                                                        BOOKING_STATUS_PENDING => 'รอยืนยัน',
-                                                        BOOKING_STATUS_CANCELLED => 'ยกเลิก',
-                                                        BOOKING_STATUS_COMPLATE => 'เสร็จสิ้น'
+                                                        BOOKING_STATUS_CONFIRMED => 'Confirmed',
+                                                        BOOKING_STATUS_PENDING => 'Pending',
+                                                        BOOKING_STATUS_CANCELLED => 'Cancelled',
+                                                        BOOKING_STATUS_COMPLATE => 'Completed'
                                                     ];
                                                     $statusClass = booking_status_badge_class($statusCode);
                                                     $statusText = $statusTexts[$statusCode] ?? booking_status_label($statusCode);
@@ -447,7 +447,7 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-6 mb-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-bar-chart me-2"></i>ประสิทธิภาพบริการ</h5>
+                                <h5><i class="bi bi-bar-chart me-2"></i>Service Performance</h5>
                             </div>
                             <div class="card-body">
                                 <?php 
@@ -458,7 +458,7 @@ for ($i = 6; $i >= 0; $i--) {
                                 <div class="mb-3">
                                     <div class="d-flex justify-content-between align-items-center mb-1">
                                         <span><?= htmlspecialchars($service['service_name']) ?></span>
-                                        <span class="text-muted"><?= $percentage ?>% (<?= $service['booking_count'] ?> ครั้ง)</span>
+                                        <span class="text-muted"><?= $percentage ?>% (<?= $service['booking_count'] ?> bookings)</span>
                                     </div>
                                     <div class="progress" style="height: 8px;">
                                         <div class="progress-bar" style="width: <?= $percentage ?>%"></div>
@@ -473,7 +473,7 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-6 mb-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-person-check me-2"></i>ประสิทธิภาพพนักงาน</h5>
+                                <h5><i class="bi bi-person-check me-2"></i>Staff Performance</h5>
                             </div>
                             <div class="card-body">
                                 <?php foreach ($staffPerformance as $staff): ?>
@@ -485,12 +485,12 @@ for ($i = 6; $i >= 0; $i--) {
                                         </div>
                                         <div>
                                             <h6 class="mb-0"><?= htmlspecialchars($staff['staff_name']) ?></h6>
-                                            <small class="text-muted">นักบำบัด</small>
+                                            <small class="text-muted">Therapist</small>
                                         </div>
                                     </div>
                                     <div class="text-end">
-                                        <div class="fw-bold text-primary"><?= $staff['booking_count'] ?> การจอง</div>
-                                        <small class="text-muted">฿<?= number_format($staff['total_revenue'], 0) ?> รายได้</small>
+                                        <div class="fw-bold text-primary"><?= $staff['booking_count'] ?> bookings</div>
+                                        <small class="text-muted">฿<?= number_format($staff['total_revenue'], 0) ?> revenue</small>
                                     </div>
                                 </div>
                                 <?php endforeach; ?>
@@ -505,24 +505,24 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-4 mb-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-cash-stack me-2"></i>สรุปการเงิน</h5>
+                                <h5><i class="bi bi-cash-stack me-2"></i>Financial Summary</h5>
                             </div>
                             <div class="card-body">
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">รายได้รวม</span>
+                                        <span class="text-muted">Gross Revenue</span>
                                         <span class="fw-bold">฿<?= number_format($kpiData['total_revenue'], 2) ?></span>
                                     </div>
                                 </div>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">ส่วนลดรวม</span>
+                                        <span class="text-muted">Total Discount</span>
                                         <span class="text-danger">-฿<?= number_format($kpiData['total_discount'], 2) ?></span>
                                     </div>
                                 </div>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">รายได้สุทธิ</span>
+                                        <span class="text-muted">Net Revenue</span>
                                         <span class="fw-bold text-success fs-5">฿<?= number_format($kpiData['net_revenue'], 2) ?></span>
                                     </div>
                                 </div>
@@ -542,13 +542,13 @@ for ($i = 6; $i >= 0; $i--) {
                                 ?>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">ชำระแล้ว</span>
+                                        <span class="text-muted">Paid</span>
                                         <span class="text-success">฿<?= number_format($paymentData['paid'], 2) ?></span>
                                     </div>
                                 </div>
                                 <div>
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">รอชำระ</span>
+                                        <span class="text-muted">Pending Payment</span>
                                         <span class="text-warning">฿<?= number_format($paymentData['pending_payment'], 2) ?></span>
                                     </div>
                                 </div>
@@ -561,7 +561,7 @@ for ($i = 6; $i >= 0; $i--) {
                     <div class="col-lg-4 mb-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5><i class="bi bi-person-hearts me-2"></i>ข้อมูลลูกค้า</h5>
+                                <h5><i class="bi bi-person-hearts me-2"></i>Customer Insights</h5>
                             </div>
                             <div class="card-body">
                                 <?php
@@ -587,31 +587,31 @@ for ($i = 6; $i >= 0; $i--) {
                                 ?>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">ลูกค้าใหม่ (30 วัน)</span>
-                                        <span class="fw-bold text-success"><?= $customerInsights['new_customers'] ?> คน</span>
+                                        <span class="text-muted">New Customers (30 days)</span>
+                                        <span class="fw-bold text-success"><?= $customerInsights['new_customers'] ?> customers</span>
                                     </div>
                                 </div>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">ลูกค้าทั้งหมด</span>
-                                        <span class="fw-bold"><?= $customerInsights['total_customers'] ?> คน</span>
+                                        <span class="text-muted">Total Customers</span>
+                                        <span class="fw-bold"><?= $customerInsights['total_customers'] ?> customers</span>
                                     </div>
                                 </div>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">มูลค่าเฉลี่ย/คน</span>
+                                        <span class="text-muted">Average Spend per Customer</span>
                                         <span class="fw-bold">฿<?= number_format($customerInsights['avg_order_value'] ?? 0, 2) ?></span>
                                     </div>
                                 </div>
                                 <div class="mb-3 pb-3 border-bottom">
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">อัตราลูกค้ากลับมา</span>
+                                        <span class="text-muted">Return Rate</span>
                                         <span class="fw-bold text-success"><?= $returnRate ?>%</span>
                                     </div>
                                 </div>
                                 <div>
                                     <div class="d-flex justify-content-between">
-                                        <span class="text-muted">คะแนนเฉลี่ย</span>
+                                        <span class="text-muted">Average Rating</span>
                                         <span class="fw-bold text-warning">4.8/5.0</span>
                                     </div>
                                 </div>
@@ -632,13 +632,13 @@ for ($i = 6; $i >= 0; $i--) {
             </button>
             <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="add_booking.php">
-                    <i class="bi bi-calendar-plus me-2"></i>เพิ่มการจอง
+                    <i class="bi bi-calendar-plus me-2"></i>New Booking
                 </a></li>
                 <li><a class="dropdown-item" href="add_customer.php">
-                    <i class="bi bi-person-plus me-2"></i>เพิ่มลูกค้า
+                    <i class="bi bi-person-plus me-2"></i>New Customer
                 </a></li>
                 <li><a class="dropdown-item" href="add_service.php">
-                    <i class="bi bi-spa me-2"></i>เพิ่มบริการ
+                    <i class="bi bi-spa me-2"></i>New Service
                 </a></li>
             </ul>
         </div>
@@ -658,7 +658,7 @@ for ($i = 6; $i >= 0; $i--) {
                 labels: revenueData.map(d => d.date),
                 datasets: [
                     {
-                        label: 'รายได้รวม (฿)',
+                        label: 'Gross Revenue (฿)',
                         data: revenueData.map(d => d.revenue),
                         borderColor: '#0d6efd',
                         backgroundColor: 'rgba(13, 110, 253, 0.1)',
@@ -667,7 +667,7 @@ for ($i = 6; $i >= 0; $i--) {
                         tension: 0.4
                     },
                     {
-                        label: 'รายได้สุทธิ (฿)',
+                        label: 'Net Revenue (฿)',
                         data: revenueData.map(d => d.net_revenue),
                         borderColor: '#198754',
                         backgroundColor: 'rgba(25, 135, 84, 0.1)',

--- a/Admin/index.php
+++ b/Admin/index.php
@@ -624,7 +624,7 @@ for ($i = 6; $i >= 0; $i--) {
     </div>
 
     <!-- Floating Action Button -->
-    <div class="position-fixed bottom-0 end-0 p-3">
+    <!-- <div class="position-fixed bottom-0 end-0 p-3">
         <div class="dropdown dropup">
             <button class="btn btn-primary rounded-circle" type="button" data-bs-toggle="dropdown" 
                     style="width: 60px; height: 60px;">
@@ -642,7 +642,7 @@ for ($i = 6; $i >= 0; $i--) {
                 </a></li>
             </ul>
         </div>
-    </div>
+    </div> -->
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>

--- a/Admin/promotion_detail.php
+++ b/Admin/promotion_detail.php
@@ -4,7 +4,7 @@ require_once 'promotion_utils.php';
 
 $promotionId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
 if ($promotionId <= 0) {
-    echo 'ไม่พบข้อมูลโปรโมชั่น';
+    echo 'Promotion not found.';
     exit;
 }
 
@@ -15,7 +15,7 @@ $promotion = $stmt->get_result()->fetch_assoc();
 $stmt->close();
 
 if (!$promotion) {
-    echo 'ไม่พบข้อมูลโปรโมชั่น';
+    echo 'Promotion not found.';
     exit;
 }
 
@@ -47,7 +47,7 @@ if ($maxPercent === 0.0) {
 
   <main id="main" class="main">
     <div class="pagetitle">
-      <h1>รายละเอียดโปรโมชั่น</h1>
+      <h1>Promotion Details</h1>
     </div>
 
     <section class="section">
@@ -58,37 +58,37 @@ if ($maxPercent === 0.0) {
 
               <div class="row mb-3">
                 <div class="col-md-6">
-                  <h5>ข้อมูลทั่วไป</h5>
+                  <h5>General Information</h5>
                   <dl class="row mb-0">
-                    <dt class="col-sm-4">ชื่อโปรโมชั่น</dt>
+                    <dt class="col-sm-4">Promotion Name</dt>
                     <dd class="col-sm-8"><?= htmlspecialchars($promotion['pm_name'] ?? '-') ?></dd>
-                    <dt class="col-sm-4">วัน-เวลาเริ่มต้น</dt>
+                    <dt class="col-sm-4">Start Date &amp; Time</dt>
                     <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_start_date'] ?? '')) ?></dd>
-                    <dt class="col-sm-4">วัน-เวลาสิ้นสุด</dt>
+                    <dt class="col-sm-4">End Date &amp; Time</dt>
                     <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_end_date'] ?? '')) ?></dd>
-                    <dt class="col-sm-4">สถานะ</dt>
+                    <dt class="col-sm-4">Status</dt>
                     <dd class="col-sm-8"><?= htmlspecialchars(promotionStatusLabel($status)) ?></dd>
-                    <dt class="col-sm-4">ส่วนลดสูงสุด</dt>
+                    <dt class="col-sm-4">Maximum Discount</dt>
                     <dd class="col-sm-8"><?= number_format($maxPercent, 2) ?>%</dd>
                     <?php if (in_array('pm_created_at', $columns, true) && !empty($promotion['pm_created_at'])): ?>
-                      <dt class="col-sm-4">สร้างเมื่อ</dt>
+                      <dt class="col-sm-4">Created At</dt>
                       <dd class="col-sm-8"><?= htmlspecialchars(formatDateTimeDisplay($promotion['pm_created_at'])) ?></dd>
                     <?php endif; ?>
                   </dl>
                 </div>
                 <div class="col-md-6">
-                  <h5>หมายเหตุ</h5>
+                  <h5>Notes</h5>
                   <?php if (!empty($promotion['description'])): ?>
                     <p><?= nl2br(htmlspecialchars($promotion['description'])) ?></p>
                   <?php else: ?>
-                    <p class="text-muted">ไม่มีรายละเอียดเพิ่มเติม</p>
+                    <p class="text-muted">No additional details.</p>
                   <?php endif; ?>
                 </div>
               </div>
 
-              <h5>บริการและส่วนลด</h5>
+              <h5>Services &amp; Discounts</h5>
               <?php if (empty($services)): ?>
-                <p class="text-muted">ไม่พบบริการในโปรโมชั่นนี้</p>
+                <p class="text-muted">No services in this promotion.</p>
               <?php else: ?>
                 <?php foreach ($services as $service): ?>
                   <div class="card border mb-3">
@@ -100,11 +100,11 @@ if ($maxPercent === 0.0) {
                         <table class="table table-bordered table-sm mb-0">
                           <thead class="table-light">
                             <tr>
-                              <th class="text-center" style="width: 120px;">ระยะเวลา (นาที)</th>
-                              <th class="text-end" style="width: 140px;">ราคาปกติ</th>
-                              <th class="text-center" style="width: 120px;">ส่วนลด (%)</th>
-                              <th class="text-end" style="width: 140px;">จำนวนส่วนลด</th>
-                              <th class="text-end" style="width: 140px;">ราคาหลังหัก</th>
+                              <th class="text-center" style="width: 120px;">Duration (minutes)</th>
+                              <th class="text-end" style="width: 140px;">Regular Price</th>
+                              <th class="text-center" style="width: 120px;">Discount (%)</th>
+                              <th class="text-end" style="width: 140px;">Discount Amount</th>
+                              <th class="text-end" style="width: 140px;">Final Price</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -126,8 +126,8 @@ if ($maxPercent === 0.0) {
               <?php endif; ?>
 
               <div class="mt-3 text-center">
-                <a href="promotion_update_form.php?id=<?= $promotionId ?>" class="btn btn-primary">แก้ไข</a>
-                <a href="table_promotion.php" class="btn btn-secondary">ย้อนกลับ</a>
+                <a href="promotion_update_form.php?id=<?= $promotionId ?>" class="btn btn-primary">Edit</a>
+                <a href="table_promotion.php" class="btn btn-secondary">Back</a>
               </div>
 
             </div>

--- a/Admin/promotion_utils.php
+++ b/Admin/promotion_utils.php
@@ -105,7 +105,7 @@ if (!function_exists('promotionStatusLabel')) {
             'upcoming' => 'upcoming',
             'running' => 'running',
             'ended' => 'ended',
-            default => 'ไม่ทราบ',
+            default => 'unknown',
         };
     }
 }

--- a/Admin/table_promotion.php
+++ b/Admin/table_promotion.php
@@ -35,7 +35,7 @@ $result = $conn->query($sql);
   <main id="main" class="main">
 
     <div class="pagetitle">
-      <h1>จัดการโปรโมชั่น</h1>
+      <h1>Manage Promotions</h1>
     </div>
 
     <section class="section">
@@ -46,7 +46,7 @@ $result = $conn->query($sql);
             <div class="card-body pt-4">
 
               <div class="text-end mb-3">
-                <a href="form_promotion.php" class="btn btn-success"><i class="bi bi-plus"></i> เพิ่มโปรโมชั่น</a>
+                <a href="form_promotion.php" class="btn btn-success"><i class="bi bi-plus"></i> Add Promotion</a>
               </div>
 
               <?php if (!empty($message)): ?>
@@ -68,13 +68,13 @@ $result = $conn->query($sql);
                   <thead class="table-light">
                     <tr>
                       <th scope="col">#</th>
-                      <th scope="col">ชื่อโปรโมชั่น</th>
-                      <th scope="col">วัน-เวลาเริ่มต้น</th>
-                      <th scope="col">วัน-เวลาสิ้นสุด</th>
-                      <th scope="col">สถานะ</th>
-                      <th scope="col" class="text-end">บริการที่เข้าร่วม</th>
-                      <th scope="col" class="text-end">ส่วนลดสูงสุด (%)</th>
-                      <th scope="col" class="text-center">การจัดการ</th>
+                      <th scope="col">Promotion Name</th>
+                      <th scope="col">Start Date &amp; Time</th>
+                      <th scope="col">End Date &amp; Time</th>
+                      <th scope="col">Status</th>
+                      <th scope="col" class="text-end">Participating Services</th>
+                      <th scope="col" class="text-end">Max Discount (%)</th>
+                      <th scope="col" class="text-center">Actions</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -116,38 +116,38 @@ $result = $conn->query($sql);
                               <a
                                 href="promotion_detail.php?id=<?= $promotionId ?>"
                                 class="btn btn-outline-primary btn-sm"
-                                title="รายละเอียด"
-                                aria-label="รายละเอียด"
+                                title="View Details"
+                                aria-label="View Details"
                               >
                                 <i class="bi bi-eye"></i>
-                                <span class="visually-hidden">รายละเอียด</span>
+                                <span class="visually-hidden">View Details</span>
                               </a>
                               <?php if ($status !== 'ended'): ?>
                                 <a
                                   href="promotion_update_form.php?id=<?= $promotionId ?>"
                                   class="btn btn-outline-secondary btn-sm"
-                                  title="แก้ไข"
-                                  aria-label="แก้ไข"
+                                  title="Edit"
+                                  aria-label="Edit"
                                 >
                                   <i class="bi bi-pencil-square"></i>
-                                  <span class="visually-hidden">แก้ไข</span>
+                                  <span class="visually-hidden">Edit</span>
                                 </a>
                               <?php endif; ?>
 
                               <?php if ($status === 'upcoming'): ?>
-                                <form action="promotion_delete.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการลบโปรโมชั่นนี้หรือไม่?');">
+                                <form action="promotion_delete.php" method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this promotion?');">
                                   <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
-                                  <button type="submit" class="btn btn-outline-danger btn-sm" title="ลบ" aria-label="ลบ">
+                                  <button type="submit" class="btn btn-outline-danger btn-sm" title="Delete" aria-label="Delete">
                                     <i class="bi bi-trash"></i>
-                                    <span class="visually-hidden">ลบ</span>
+                                    <span class="visually-hidden">Delete</span>
                                   </button>
                                 </form>
                               <?php elseif ($status === 'running'): ?>
-                                <form action="promotion_end.php" method="post" class="d-inline" onsubmit="return confirm('ต้องการสิ้นสุดโปรโมชั่นนี้ทันทีหรือไม่?');">
+                                <form action="promotion_end.php" method="post" class="d-inline" onsubmit="return confirm('Do you want to end this promotion immediately?');">
                                   <input type="hidden" name="promotion_id" value="<?= $promotionId ?>">
-                                  <button type="submit" class="btn btn-outline-warning btn-sm" title="สิ้นสุดทันที" aria-label="สิ้นสุดทันที">
+                                  <button type="submit" class="btn btn-outline-warning btn-sm" title="End Now" aria-label="End Now">
                                     <i class="bi bi-stop-circle"></i>
-                                    <span class="visually-hidden">สิ้นสุดทันที</span>
+                                    <span class="visually-hidden">End Now</span>
                                   </button>
                                 </form>
                               <?php else: ?>
@@ -159,7 +159,7 @@ $result = $conn->query($sql);
                       <?php endwhile; ?>
                     <?php else: ?>
                       <tr>
-                        <td colspan="8" class="text-center text-muted">ยังไม่มีข้อมูลโปรโมชั่น</td>
+                        <td colspan="8" class="text-center text-muted">No promotions available yet.</td>
                       </tr>
                     <?php endif; ?>
                   </tbody>


### PR DESCRIPTION
## Summary
- translate the promotion management table interface into English, including headings, buttons, and prompts
- update the default promotion status label to use an English fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68feec66e8cc832da34736cb3ea85e57